### PR TITLE
Determine transfer protocol more precisely

### DIFF
--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -1927,10 +1927,9 @@ class ApiConfigGenerator(object):
     """
     hostname = (hostname or endpoints_util.get_app_hostname() or
                 api_info.hostname)
-    protocol = ('http' if hostname and hostname.startswith('localhost') else
-                'https')
-    protocol = ('http' if hostname and hostname.startswith('localhost') else
-                'https')
+    protocol = 'http' if ((hostname and hostname.startswith('localhost')) or
+                          endpoints_util.is_running_on_devserver()) else 'https'
+
     defaults = {
         'extends': 'thirdParty.api',
         'root': '{0}://{1}/_ah/api'.format(protocol, hostname),

--- a/endpoints/swagger_generator.py
+++ b/endpoints/swagger_generator.py
@@ -835,10 +835,8 @@ class SwaggerGenerator(object):
     """
     hostname = (hostname or util.get_app_hostname() or
                 api_info.hostname)
-    protocol = ('http' if hostname and hostname.startswith('localhost') else
-                'https')
-    protocol = ('http' if hostname and hostname.startswith('localhost') else
-                'https')
+    protocol = 'http' if ((hostname and hostname.startswith('localhost')) or
+                          util.is_running_on_devserver()) else 'https'
     defaults = {
         'swagger': '2.0',
         'info': {

--- a/endpoints/test/test_util.py
+++ b/endpoints/test/test_util.py
@@ -22,6 +22,7 @@ Classes:
 
 import __future__
 import json
+import os
 import types
 
 
@@ -174,3 +175,21 @@ class ModuleInterfaceTest(object):
           exported_modules.append(attribute)
     if exported_modules:
       self.fail('%s are modules and may not be exported.' % exported_modules)
+
+
+class DevServerTest(object):
+
+  @staticmethod
+  def setUpDevServerEnv(server_software_key='SERVER_SOFTWARE',
+                        server_software_value='Development/2.0.0'):
+    original_env_value = os.environ.get(server_software_key)
+    os.environ[server_software_key] = server_software_value
+    return server_software_key, original_env_value
+
+  @staticmethod
+  def restoreEnv(server_software_key, server_software_value):
+    if server_software_value is None:
+      os.environ.pop(server_software_key, None)
+    else:
+      os.environ[server_software_key] = server_software_value
+

--- a/endpoints/util.py
+++ b/endpoints/util.py
@@ -184,7 +184,11 @@ def put_headers_in_environ(headers, environ):
 
 
 def is_running_on_app_engine():
-  return os.environ.get('SERVER_SOFTWARE', '').startswith('Google App Engine/')
+  return os.environ.get('GAE_MODULE_NAME') is not None
+
+
+def is_running_on_devserver():
+  return os.environ.get('SERVER_SOFTWARE', '').startswith('Development/')
 
 
 def is_running_on_localhost():


### PR DESCRIPTION
If the config is being generated locally (using endpointscfg.py), we stick to the old logic of "HTTP if localhost else HTTPS". When it's being generated remotely (using apiserving.py), we use the new logic: "HTTP if running on development server, else HTTPS"