### PR TITLE
Allow for colons mixed with path params in last path part

### DIFF
--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -86,6 +86,10 @@ _INVALID_NAMESPACE_ERROR_TEMPLATE = (
     '%s. package_path is optional.')
 
 
+_VALID_PART_RE = re.compile('^{[^{}]+}$')
+_VALID_LAST_PART_RE = re.compile('^{[^{}]+}(:)?(?(1)[^{}]+)$')
+
+
 Issuer = collections.namedtuple('Issuer', ['issuer', 'jwks_uri'])
 Namespace = collections.namedtuple('Namespace', ['owner_domain',
                                                  'owner_name',
@@ -1064,10 +1068,9 @@ class _MethodInfo(object):
     # Verify that the path seems valid.
     parts = path.split('/')
     for n, part in enumerate(parts):
+      r = _VALID_PART_RE if n < len(parts) - 1 else _VALID_LAST_PART_RE
       if part and '{' in part and '}' in part:
-        if (re.match('^{[^{}]+}$', part) is None and
-            (n < len(parts) - 1 or
-             re.match('^{[^{}]+}(:)?(?(1)[^{}]+)$', part) is None)):
+        if not r.match(part):
           raise api_exceptions.ApiConfigurationError(
               'Invalid path segment: %s (part of %s)' % (part, path))
     return path

--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -1062,9 +1062,12 @@ class _MethodInfo(object):
         path = '%s%s%s' % (api_info.path, '/' if path else '', path)
 
     # Verify that the path seems valid.
-    for part in path.split('/'):
+    parts = path.split('/')
+    for n, part in enumerate(parts):
       if part and '{' in part and '}' in part:
-        if re.match('^{[^{}]+}$', part) is None:
+        if (re.match('^{[^{}]+}$', part) is None and
+            (n < len(parts) - 1 or
+             re.match('^{[^{}]+}(:)?(?(1)[^{}]+)$', part) is None)):
           raise api_exceptions.ApiConfigurationError(
               'Invalid path segment: %s (part of %s)' % (part, path))
     return path

--- a/endpoints/api_config_manager.py
+++ b/endpoints/api_config_manager.py
@@ -26,7 +26,7 @@ import discovery_service
 
 # Internal constants
 _PATH_VARIABLE_PATTERN = r'[a-zA-Z_][a-zA-Z_.\d]*'
-_PATH_VALUE_PATTERN = r'[^:/?#\[\]{}]*'
+_PATH_VALUE_PATTERN = r'[^/?#\[\]{}]*'
 
 
 class ApiConfigManager(object):
@@ -197,7 +197,6 @@ class ApiConfigManager(object):
         <params> is a dict of path parameters matched in the rest request.
     """
     with self._config_lock:
-      path = urllib.quote(path)
       for compiled_path_pattern, unused_path, methods in self._rest_methods:
         match = compiled_path_pattern.match(path)
         if match:

--- a/endpoints/api_config_manager.py
+++ b/endpoints/api_config_manager.py
@@ -279,7 +279,7 @@ class ApiConfigManager(object):
     r"""Generates a compiled regex pattern for a path pattern.
 
     e.g. '/MyApi/v1/notes/{id}'
-    returns re.compile(r'/MyApi/v1/notes/(?P<id>[^:/?#\[\]{}]*)')
+    returns re.compile(r'/MyApi/v1/notes/(?P<id>[^/?#\[\]{}]*)')
 
     Args:
       pattern: A string, the parameterized path pattern to be checked.
@@ -310,7 +310,7 @@ class ApiConfigManager(object):
                                  _PATH_VALUE_PATTERN)
       return match.group(0)
 
-    pattern = re.sub('(/|^){(%s)}(?=/|$)' % _PATH_VARIABLE_PATTERN,
+    pattern = re.sub('(/|^){(%s)}(?=/|$|:)' % _PATH_VARIABLE_PATTERN,
                      replace_variable, pattern)
     return re.compile(pattern + '/?$')
 

--- a/endpoints/test/api_config_manager_test.py
+++ b/endpoints/test/api_config_manager_test.py
@@ -194,6 +194,17 @@ class ApiConfigManagerTest(unittest.TestCase):
     self.assertEqual(fake_method, method_spec)
     self.assertEqual({'id': 'i'}, params)
 
+  def test_lookup_rest_method_with_colon_in_path(self):
+    fake_method = {'httpMethod': 'GET',
+                   'path': 'greetings/greeting:xmas'}
+    self.config_manager._save_rest_method('guestbook_api.get', 'guestbook_api',
+                                          'v1', fake_method)
+
+    method_name, method_spec, _ = self.config_manager.lookup_rest_method(
+        'guestbook_api/v1/greetings/greeting:xmas', 'GET')
+    self.assertEqual('guestbook_api.get', method_name)
+    self.assertEqual(fake_method, method_spec)
+
   def test_lookup_rest_method_with_colon_in_param(self):
     fake_method = {'httpMethod': 'GET',
                    'path': 'greetings/{id}'}
@@ -331,7 +342,7 @@ class ParameterizedPathTest(unittest.TestCase):
     self.assertEqual(None, params)
 
   def test_invalid_values(self):
-    for reserved in [':', '?', '#', '[', ']', '{', '}']:
+    for reserved in ['?', '#', '[', ']', '{', '}']:
       self.assert_invalid_value('123%s' % reserved)
 
 

--- a/endpoints/test/api_config_manager_test.py
+++ b/endpoints/test/api_config_manager_test.py
@@ -216,6 +216,28 @@ class ApiConfigManagerTest(unittest.TestCase):
     self.assertEqual('guestbook_api.get', method_name)
     self.assertEqual(fake_method, method_spec)
 
+  def test_lookup_rest_method_with_colon_after_param(self):
+    fake_method = {'httpMethod': 'GET',
+                   'path': 'greetings/{id}:hello'}
+    self.config_manager._save_rest_method('guestbook_api.get', 'guestbook_api',
+                                          'v1', fake_method)
+
+    method_name, method_spec, _ = self.config_manager.lookup_rest_method(
+        'guestbook_api/v1/greetings/1:hello', 'GET')
+    self.assertEqual('guestbook_api.get', method_name)
+    self.assertEqual(fake_method, method_spec)
+
+  def test_lookup_rest_method_with_colon_in_and_after_param(self):
+    fake_method = {'httpMethod': 'GET',
+                   'path': 'greetings/{id}:hello'}
+    self.config_manager._save_rest_method('guestbook_api.get', 'guestbook_api',
+                                          'v1', fake_method)
+
+    method_name, method_spec, _ = self.config_manager.lookup_rest_method(
+        'guestbook_api/v1/greetings/greeting:colon:hello', 'GET')
+    self.assertEqual('guestbook_api.get', method_name)
+    self.assertEqual(fake_method, method_spec)
+
   def test_trailing_slash_optional(self):
     # Create a typical get resource URL.
     fake_method = {'httpMethod': 'GET', 'path': 'trailingslash'}

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -2247,7 +2247,8 @@ class MethodDecoratorTest(unittest.TestCase):
         pass
 
       @api_config.method(MyRequest, message_types.VoidMessage,
-                         path='zebras/{zebra}/pandas/{panda}/kittens/{kitten}')
+                         path='zebras/{zebra}/pandas/{panda}'
+                              '/kittens/{kitten}:human')
       def specified_path_method(self):
         pass
 
@@ -2257,7 +2258,7 @@ class MethodDecoratorTest(unittest.TestCase):
     self.assertEqual(message_types.VoidMessage,
                      specified_protorpc_info.response_type)
     self.assertEqual('specified_path_method', specified_path_info.name)
-    self.assertEqual('zebras/{zebra}/pandas/{panda}/kittens/{kitten}',
+    self.assertEqual('zebras/{zebra}/pandas/{panda}/kittens/{kitten}:human',
                      specified_path_info.get_path(MyDecoratedService.api_info))
     self.assertEqual('POST', specified_path_info.http_method)
     self.assertEqual(None, specified_path_info.scopes)
@@ -2284,7 +2285,9 @@ class MethodDecoratorTest(unittest.TestCase):
                  'invalid/{param}mixed',
                  'invalid/mixed{param}mixed',
                  'invalid/{extra}{vars}',
-                 'invalid/{}/emptyvar'):
+                 'invalid/{}/emptyvar',
+                 'invalid/{param}:abc/emptyvar'
+                 ):
 
       @api_config.api('root', 'v1')
       class MyDecoratedService(remote.Service):

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -2286,8 +2286,7 @@ class MethodDecoratorTest(unittest.TestCase):
                  'invalid/mixed{param}mixed',
                  'invalid/{extra}{vars}',
                  'invalid/{}/emptyvar',
-                 'invalid/{param}:abc/emptyvar'
-                 ):
+                 'invalid/{param}:abc/emptyvar'):
 
       @api_config.api('root', 'v1')
       class MyDecoratedService(remote.Service):


### PR DESCRIPTION
See https://cloud.google.com/apis/design/custom_methods for more information. get_path was failing when a producer tried to do the following:

/path/to/endpoint/{param}:custom

...which the custom methods guide says should be possible.