### PR TITLE
Handle multiple api versions properly in discovery service.

### DIFF
--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -817,6 +817,15 @@ class DiscoveryGenerator(object):
     Returns:
       The _ApiInfo object to use for the API that the given services implement.
     """
+    base_paths = sorted(set([s.api_info.base_path for s in services]))
+    if len(base_paths) != 1:
+      raise api_exceptions.ApiConfigurationError(
+          'Multiple base_paths found: {!r}'.format(base_paths))
+    names_versions = sorted(set(
+        [(s.api_info.name, s.api_info.version) for s in services]))
+    if len(names_versions) != 1:
+      raise api_exceptions.ApiConfigurationError(
+          'Multiple apis/versions found: {!r}'.format(names_versions))
     return services[0].api_info
 
   def __discovery_doc_descriptor(self, services, hostname=None):

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -817,12 +817,12 @@ class DiscoveryGenerator(object):
     Returns:
       The _ApiInfo object to use for the API that the given services implement.
     """
-    base_paths = sorted(set([s.api_info.base_path for s in services]))
+    base_paths = sorted(set(s.api_info.base_path for s in services))
     if len(base_paths) != 1:
       raise api_exceptions.ApiConfigurationError(
           'Multiple base_paths found: {!r}'.format(base_paths))
     names_versions = sorted(set(
-        [(s.api_info.name, s.api_info.version) for s in services]))
+        (s.api_info.name, s.api_info.version) for s in services))
     if len(names_versions) != 1:
       raise api_exceptions.ApiConfigurationError(
           'Multiple apis/versions found: {!r}'.format(names_versions))

--- a/endpoints/discovery_service.py
+++ b/endpoints/discovery_service.py
@@ -86,7 +86,7 @@ class DiscoveryService(object):
       A string, the response body.
     """
     headers = [('Content-Type', 'application/json; charset=UTF-8')]
-    return util.send_wsgi_response('200', headers, response, start_response)
+    return util.send_wsgi_response('200 OK', headers, response, start_response)
 
   def _get_rest_doc(self, request, start_response):
     """Sends back HTTP response with API directory.
@@ -105,7 +105,9 @@ class DiscoveryService(object):
     version = request.body_json['version']
 
     generator = discovery_generator.DiscoveryGenerator(request=request)
-    doc = generator.pretty_print_config_to_json(self._backend.api_services)
+    services = [s for s in self._backend.api_services if
+                s.api_info.name == api and s.api_info.version == version]
+    doc = generator.pretty_print_config_to_json(services)
     if not doc:
       error_msg = ('Failed to convert .api to discovery doc for '
                    'version %s of api %s') % (version, api)

--- a/endpoints/test/discovery_generator_test.py
+++ b/endpoints/test/discovery_generator_test.py
@@ -19,6 +19,7 @@ import os
 import unittest
 
 import endpoints.api_config as api_config
+import endpoints.api_exceptions as api_exceptions
 
 from protorpc import message_types
 from protorpc import messages
@@ -273,6 +274,72 @@ class DiscoveryGeneratorTest(BaseDiscoveryGeneratorTest):
     expected_discovery['packagePath'] = ''
 
     test_util.AssertDictEqual(expected_discovery, api, self)
+
+class DiscoveryVersionGeneratorTest(BaseDiscoveryGeneratorTest):
+
+  def testMethodCollisionDetection(self):
+    '''While multiple classes can be passed to the generator at once,
+    they should all belong to the same api and version.'''
+    class Airport(messages.Message):
+      iata = messages.StringField(1, required=True)
+      name = messages.StringField(2, required=True)
+
+    class AirportList(messages.Message):
+      airports = messages.MessageField(Airport, 1, repeated=True)
+
+    @api_config.api(name='iata', version='v1')
+    class V1Service(remote.Service):
+      @api_config.method(
+          message_types.VoidMessage,
+          AirportList,
+          path='airports',
+          http_method='GET',
+          name='list_airports')
+      def list_airports(self, request):
+        return AirportList(airports=[
+            Airport(iata=u'DEN', name=u'Denver International Airport'),
+            Airport(iata=u'SEA', name=u'Seattle Tacoma International Airport'),
+        ])
+
+    @api_config.api(name='iata', version='v2')
+    class V2Service(remote.Service):
+      @api_config.method(
+          message_types.VoidMessage,
+          AirportList,
+          path='airports',
+          http_method='GET',
+          name='list_airports')
+      def list_airports(self, request):
+        return AirportList(airports=[
+            Airport(iata=u'DEN', name=u'Denver International Airport'),
+            Airport(iata=u'JFK', name=u'John F Kennedy International Airport'),
+            Airport(iata=u'SEA', name=u'Seattle Tacoma International Airport'),
+        ])
+
+    error = "Multiple apis/versions found: [('iata', 'v1'), ('iata', 'v2')]"
+    with self.assertRaises(api_exceptions.ApiConfigurationError) as catcher:
+      self.generator.get_discovery_doc([V1Service, V2Service])
+    self.assertEqual(catcher.exception.message, error)
+
+
+    @api_config.api(name='iata', version='v1')
+    class V1ServiceCont(remote.Service):
+      @api_config.method(
+          message_types.VoidMessage,
+          AirportList,
+          path='airports',
+          http_method='GET',
+          name='list_airports')
+      def list_airports(self, request):
+        return AirportList(airports=[
+            Airport(iata=u'JFK', name=u'John F Kennedy International Airport'),
+        ])
+
+    error = "Method iata.list_airports used multiple times"
+    with self.assertRaises(api_exceptions.ApiConfigurationError) as catcher:
+      self.generator.get_discovery_doc([V1Service, V1ServiceCont])
+    self.assertEqual(catcher.exception.message[:len(error)], error)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The available services were not properly being filtered for the requested api and version, which led to invalid information in the best case and exceptions in the worst case. (Or maybe those cases should be the other way around.)

Fixes #74, #70.