### PR TITLE
Automatically mark path params as required.

### DIFF
--- a/endpoints/openapi_generator.py
+++ b/endpoints/openapi_generator.py
@@ -407,6 +407,7 @@ class OpenApiGenerator(object):
 
   def __path_parameter_descriptor(self, param):
     descriptor = self.__non_body_parameter_descriptor(param)
+    descriptor['required'] = True
     descriptor['in'] = 'path'
 
     return descriptor


### PR DESCRIPTION
Some users wanted path params to be required no matter whether manually specified as such or not.