### PR TITLE
Set scopes properly in discovery doc

### DIFF
--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -33,7 +33,6 @@ the API is returned.
 # pylint: disable=g-bad-name
 
 # pylint: disable=g-statement-before-imports,g-import-not-at-top
-import collections
 import json
 import logging
 import re
@@ -45,6 +44,8 @@ from protorpc import message_types
 from protorpc import messages
 from protorpc import remote
 from protorpc import util
+
+import attr
 
 import resource_container
 import users_id_token
@@ -90,13 +91,13 @@ _INVALID_NAMESPACE_ERROR_TEMPLATE = (
     '%s. package_path is optional.')
 
 
-Issuer = collections.namedtuple('Issuer', ['issuer', 'jwks_uri'])
-LimitDefinition = collections.namedtuple('LimitDefinition', ['metric_name',
-                                                             'display_name',
-                                                             'default_limit'])
-Namespace = collections.namedtuple('Namespace', ['owner_domain',
-                                                 'owner_name',
-                                                 'package_path'])
+Issuer = attr.make_class('Issuer', ['issuer', 'jwks_uri'])
+LimitDefinition = attr.make_class('LimitDefinition', ['metric_name',
+                                                      'display_name',
+                                                      'default_limit'])
+Namespace = attr.make_class('Namespace', ['owner_domain',
+                                          'owner_name',
+                                          'package_path'])
 
 
 def _Enum(docstring, *names):

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -796,14 +796,14 @@ class DiscoveryGenerator(object):
         },
     }
 
-  def __standard_auth_descriptor(self):
+  def __standard_auth_descriptor(self, services):
+    scopes = {}
+    for service in services:
+      for scope in service.api_info.scope_objs:
+        scopes[scope.scope] = {'description': scope.description}
     return {
         'oauth2': {
-            'scopes': {
-                'https://www.googleapis.com/auth/userinfo.email': {
-                    'description': 'View your email address'
-                }
-            }
+            'scopes': scopes
         }
     }
 
@@ -857,7 +857,7 @@ class DiscoveryGenerator(object):
       descriptor['description'] = description
 
     descriptor['parameters'] = self.__standard_parameters_descriptor()
-    descriptor['auth'] = self.__standard_auth_descriptor()
+    descriptor['auth'] = self.__standard_auth_descriptor(services)
 
     # Add namespace information, if provided
     if merged_api_info.namespace:

--- a/endpoints/test/users_id_token_test.py
+++ b/endpoints/test/users_id_token_test.py
@@ -875,5 +875,18 @@ class JwtTest(UsersIdTokenTestBase):
         self._SAMPLE_CERT_URI, self.cache)
     self.assertIsNone(parsed_token)
 
+class TestOAuth2Scope(unittest.TestCase):
+  def testScope(self):
+    sample = users_id_token.OAuth2Scope(scope='foo', description='bar')
+    converted = users_id_token.OAuth2Scope(scope='foo', description='foo')
+    self.assertEqual(sample.scope, 'foo')
+    self.assertEqual(sample.description, 'bar')
+
+    self.assertEqual(users_id_token.OAuth2Scope.convert_scope(sample), sample)
+    self.assertEqual(users_id_token.OAuth2Scope.convert_scope('foo'), converted)
+
+    self.assertIsNone(users_id_token.OAuth2Scope.convert_list(None))
+    self.assertEqual(users_id_token.OAuth2Scope.convert_list([sample, 'foo']), [sample, converted])
+
 if __name__ == '__main__':
   unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+attrs>=17.2.0
 google-endpoints-api-management>=1.2.1
 setuptools>=36.2.5

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ with open('endpoints/__init__.py', 'r') as f:
         raise RuntimeError("No version number found!")
 
 install_requires = [
+    'attrs>=17.2.0',
     'google-endpoints-api-management>=1.2.1',
     'setuptools>=36.2.5',
 ]


### PR DESCRIPTION
We now provide the api's defined oauth scopes in the discovery doc. Additionally, scopes can be passed as an object which contains both the scope name and a description.

For example:
```python
@api(name='example', scopes=['https://www.googleapis.com/auth/santa'])
```

This lacks a description, so it will be presented to the user as that URI. Instead, we can do this:
```python
scope = OAuth2Scope(
    scope='https://www.googleapis.com/auth/santa',
    description='Access your letter to Santa')
@api(name='example', scopes=[scope])
```

And the description will be included in the discovery doc.