### PR TITLE
Automatically allow the API Explorer client id when running locally.

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -20,7 +20,6 @@
 # pylint: disable=wildcard-import
 
 from api_config import api
-from api_config import API_EXPLORER_CLIENT_ID
 from api_config import AUTH_LEVEL
 from api_config import EMAIL_SCOPE
 from api_config import Issuer
@@ -30,6 +29,7 @@ from apiserving import *
 from endpoints_dispatcher import *
 import message_parser
 from resource_container import ResourceContainer
+from users_id_token import API_EXPLORER_CLIENT_ID
 from users_id_token import get_current_user, get_verified_jwt, convert_jwks_uri
 from users_id_token import InvalidGetUserCall
 from users_id_token import SKIP_CLIENT_ID_CHECK

--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -58,7 +58,6 @@ package = 'google.appengine.endpoints'
 
 
 __all__ = [
-    'API_EXPLORER_CLIENT_ID',
     'ApiAuth',
     'ApiConfigGenerator',
     'ApiFrontEndLimitRule',
@@ -74,7 +73,6 @@ __all__ = [
 ]
 
 
-API_EXPLORER_CLIENT_ID = '292824132082.apps.googleusercontent.com'
 EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email'
 _EMAIL_SCOPE_DESCRIPTION = 'View your email address'
 _EMAIL_SCOPE_OBJ = users_id_token.OAuth2Scope(
@@ -605,7 +603,7 @@ class _ApiDecorator(object):
       else:
         scopes = users_id_token.OAuth2Scope.convert_list(scopes)
       if allowed_client_ids is None:
-        allowed_client_ids = [API_EXPLORER_CLIENT_ID]
+        allowed_client_ids = [users_id_token.API_EXPLORER_CLIENT_ID]
       if auth_level is None:
         auth_level = AUTH_LEVEL.NONE
       if api_key_required is None:

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -22,6 +22,7 @@ import unittest
 import endpoints.api_config as api_config
 from endpoints.api_config import ApiConfigGenerator
 from endpoints.api_config import AUTH_LEVEL
+from endpoints.users_id_token import API_EXPLORER_CLIENT_ID
 import endpoints.api_exceptions as api_exceptions
 import mock
 from protorpc import message_types
@@ -278,7 +279,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_get',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.getContainer': {
@@ -347,7 +348,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_get_container',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
         },
         'root.entries.publishContainer': {
@@ -371,7 +372,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_publish_container',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.put': {
@@ -387,7 +388,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_put',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.process': {
@@ -403,7 +404,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_process',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.nested.collection.action': {
@@ -418,7 +419,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_nested_collection_action',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.roundtrip': {
@@ -435,7 +436,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_roundtrip',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.publish': {
@@ -461,7 +462,7 @@ class ApiConfigTest(unittest.TestCase):
                  },
             'rosyMethod': 'MyService.entries_publish',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.items.put': {
@@ -487,7 +488,7 @@ class ApiConfigTest(unittest.TestCase):
                  },
             'rosyMethod': 'MyService.items_put',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.items.putContainer': {
@@ -513,7 +514,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.items_put_container',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             }
         }
@@ -971,7 +972,7 @@ class ApiConfigTest(unittest.TestCase):
             },
         'rosyMethod': 'MySimpleService.get',
         'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-        'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+        'clientIds': [API_EXPLORER_CLIENT_ID],
         'authLevel': 'NONE',
         }
 
@@ -1028,7 +1029,7 @@ class ApiConfigTest(unittest.TestCase):
       self.assertEqual(cls.api_info.hostname, 'example.appspot.com')
       self.assertIsNone(cls.api_info.audiences)
       self.assertEqual(cls.api_info.allowed_client_ids,
-                       [api_config.API_EXPLORER_CLIENT_ID])
+                       [API_EXPLORER_CLIENT_ID])
       self.assertEqual(cls.api_info.scopes, [api_config.EMAIL_SCOPE])
 
     # Get the config for the combination of all 3.
@@ -1167,7 +1168,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service1.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1177,7 +1178,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service2.list',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1303,7 +1304,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service1.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1313,7 +1314,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service2.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1370,7 +1371,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'autoTemplate(backendResponse)',
                          'bodyName': 'resource'},
             'rosyMethod': 'Service1.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1388,7 +1389,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'autoTemplate(backendResponse)',
                          'bodyName': 'resource'},
             'rosyMethod': 'Service2.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1639,7 +1640,7 @@ class ApiConfigTest(unittest.TestCase):
         'response': {'body': 'empty'},
         'rosyMethod': 'MyService.items_update',
         'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-        'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+        'clientIds': [API_EXPLORER_CLIENT_ID],
         'authLevel': 'NONE',
         }
 
@@ -1686,7 +1687,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'empty'},
             'rosyMethod': 'MyService.items_get',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             }
         }
@@ -1722,7 +1723,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'empty'},
             'rosyMethod': 'MyService.items_get',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'REQUIRED',
             }
         }
@@ -1989,7 +1990,7 @@ class ApiDecoratorTest(unittest.TestCase):
     self.assertEqual('Cool Service Name', api_info.canonical_name)
     self.assertIsNone(api_info.audiences)
     self.assertEqual([api_config.EMAIL_SCOPE], api_info.scopes)
-    self.assertEqual([api_config.API_EXPLORER_CLIENT_ID],
+    self.assertEqual([API_EXPLORER_CLIENT_ID],
                      api_info.allowed_client_ids)
     self.assertEqual(AUTH_LEVEL.NONE, api_info.auth_level)
     self.assertEqual(None, api_info.resource_name)
@@ -2306,7 +2307,7 @@ class MethodDecoratorTest(unittest.TestCase):
         'scopes', 'scopes',
         ['https://www.googleapis.com/auth/userinfo.email'])
     self.TryListAttributeVariations('allowed_client_ids', 'clientIds',
-                                    [api_config.API_EXPLORER_CLIENT_ID])
+                                    [API_EXPLORER_CLIENT_ID])
 
   def TryListAttributeVariations(self, attribute_name, config_name,
                                  default_expected):
@@ -2365,7 +2366,7 @@ class MethodDecoratorTest(unittest.TestCase):
               'response': {'body': 'empty'},
               'rosyMethod': 'AuthServiceImpl.baz',
               'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-              'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+              'clientIds': [API_EXPLORER_CLIENT_ID],
               'authLevel': 'NONE'
               }
           }

--- a/endpoints/test/users_id_token_test.py
+++ b/endpoints/test/users_id_token_test.py
@@ -23,7 +23,7 @@ import unittest
 
 import endpoints.api_config as api_config
 
-import mox
+import mox  # TODO: replace this with mock
 from protorpc import message_types
 from protorpc import messages
 from protorpc import remote
@@ -412,7 +412,7 @@ class UsersIdTokenTest(UsersIdTokenTestBase):
     self.assertOauthSucceeded(self._SAMPLE_ALLOWED_CLIENT_IDS[0])
 
   def testOauthExplorerClientId(self):
-    self.assertOauthFailed(api_config.API_EXPLORER_CLIENT_ID)
+    self.assertOauthFailed(users_id_token.API_EXPLORER_CLIENT_ID)
 
   def testOauthInvalidScope(self):
     self.assertOauthFailed(None)
@@ -653,6 +653,8 @@ class UsersIdTokenTestWithSimpleApi(UsersIdTokenTestBase):
     # will never be attempted
 
     self.mox.StubOutWithMock(users_id_token, '_is_local_dev')
+    # allow two calls
+    users_id_token._is_local_dev().AndReturn(False)
     users_id_token._is_local_dev().AndReturn(False)
 
     self.mox.StubOutWithMock(oauth, 'get_client_id')

--- a/endpoints/users_id_token.py
+++ b/endpoints/users_id_token.py
@@ -49,13 +49,17 @@ except ImportError:
   _CRYPTO_LOADED = False
 
 
-__all__ = ['get_current_user',
-           'get_verified_jwt',
-           'convert_jwks_uri',
-           'InvalidGetUserCall',
-           'SKIP_CLIENT_ID_CHECK',
-           'OAuth2Scope']
+__all__ = [
+    'API_EXPLORER_CLIENT_ID',
+    'convert_jwks_uri',
+    'get_current_user',
+    'get_verified_jwt',
+    'InvalidGetUserCall',
+    'OAuth2Scope',
+    'SKIP_CLIENT_ID_CHECK',
+]
 
+API_EXPLORER_CLIENT_ID = '292824132082.apps.googleusercontent.com'
 SKIP_CLIENT_ID_CHECK = ['*']  # This needs to be a list, for comparisons.
 _CLOCK_SKEW_SECS = 300  # 5 minutes in seconds
 _MAX_TOKEN_LIFETIME_SECS = 86400  # 1 day in seconds
@@ -200,6 +204,9 @@ def _maybe_set_current_user_vars(method, api_info=None, request=None):
   token = _get_token(request)
   if not token:
     return None
+
+  if allowed_client_ids and _is_local_dev():
+    allowed_client_ids = tuple(API_EXPLORER_CLIENT_ID, *allowed_client_ids)
 
   # When every item in the acceptable scopes list is
   # "https://www.googleapis.com/auth/userinfo.email", and there is a non-empty


### PR DESCRIPTION
Feature request so users don't have to remember to add it to the whitelist.