### PR TITLE
Bump minor version (2.3.1 -> 2.4.0)

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -34,4 +34,4 @@ from users_id_token import get_current_user, get_verified_jwt, convert_jwks_uri
 from users_id_token import InvalidGetUserCall
 from users_id_token import SKIP_CLIENT_ID_CHECK
 
-__version__ = '2.3.1'
+__version__ = '2.4.0'


### PR DESCRIPTION
Rationale:

* Discovery docs now properly contain the OAuth2 scopes
* Improved security definition generation in OpenAPI specs