### PR TITLE
Automatically allow the API Explorer client id when running locally.

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -20,13 +20,13 @@
 # pylint: disable=wildcard-import
 
 from api_config import api
-from api_config import API_EXPLORER_CLIENT_ID
 from api_config import AUTH_LEVEL
 from api_config import EMAIL_SCOPE
 from api_config import Issuer
 from api_config import method
 from api_exceptions import *
 from apiserving import *
+from constants import API_EXPLORER_CLIENT_ID
 from endpoints_dispatcher import *
 import message_parser
 from resource_container import ResourceContainer

--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -51,6 +51,7 @@ import resource_container
 import users_id_token
 import util as endpoints_util
 import types as endpoints_types
+import constants
 
 from google.appengine.api import app_identity
 
@@ -59,7 +60,6 @@ package = 'google.appengine.endpoints'
 
 
 __all__ = [
-    'API_EXPLORER_CLIENT_ID',
     'ApiAuth',
     'ApiConfigGenerator',
     'ApiFrontEndLimitRule',
@@ -75,7 +75,6 @@ __all__ = [
 ]
 
 
-API_EXPLORER_CLIENT_ID = '292824132082.apps.googleusercontent.com'
 EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email'
 _EMAIL_SCOPE_DESCRIPTION = 'View your email address'
 _EMAIL_SCOPE_OBJ = endpoints_types.OAuth2Scope(
@@ -606,7 +605,7 @@ class _ApiDecorator(object):
       else:
         scopes = endpoints_types.OAuth2Scope.convert_list(scopes)
       if allowed_client_ids is None:
-        allowed_client_ids = [API_EXPLORER_CLIENT_ID]
+        allowed_client_ids = [constants.API_EXPLORER_CLIENT_ID]
       if auth_level is None:
         auth_level = AUTH_LEVEL.NONE
       if api_key_required is None:

--- a/endpoints/constants.py
+++ b/endpoints/constants.py
@@ -1,0 +1,27 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provide various constants needed by Endpoints Framework.
+
+Putting them in this file makes it easier to avoid circular imports,
+as well as keep from complicating tests due to importing code that
+uses App Engine apis.
+"""
+
+__all__ = [
+    'API_EXPLORER_CLIENT_ID',
+]
+
+
+API_EXPLORER_CLIENT_ID = '292824132082.apps.googleusercontent.com'

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -22,6 +22,7 @@ import unittest
 import endpoints.api_config as api_config
 from endpoints.api_config import ApiConfigGenerator
 from endpoints.api_config import AUTH_LEVEL
+from endpoints.constants import API_EXPLORER_CLIENT_ID
 import endpoints.api_exceptions as api_exceptions
 import mock
 from protorpc import message_types
@@ -278,7 +279,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_get',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.getContainer': {
@@ -347,7 +348,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_get_container',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
         },
         'root.entries.publishContainer': {
@@ -371,7 +372,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_publish_container',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.put': {
@@ -387,7 +388,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_put',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.process': {
@@ -403,7 +404,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_process',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.nested.collection.action': {
@@ -418,7 +419,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_nested_collection_action',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.roundtrip': {
@@ -435,7 +436,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.entries_roundtrip',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.publish': {
@@ -461,7 +462,7 @@ class ApiConfigTest(unittest.TestCase):
                  },
             'rosyMethod': 'MyService.entries_publish',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.items.put': {
@@ -487,7 +488,7 @@ class ApiConfigTest(unittest.TestCase):
                  },
             'rosyMethod': 'MyService.items_put',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             },
         'root.entries.items.putContainer': {
@@ -513,7 +514,7 @@ class ApiConfigTest(unittest.TestCase):
                 },
             'rosyMethod': 'MyService.items_put_container',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             }
         }
@@ -971,7 +972,7 @@ class ApiConfigTest(unittest.TestCase):
             },
         'rosyMethod': 'MySimpleService.get',
         'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-        'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+        'clientIds': [API_EXPLORER_CLIENT_ID],
         'authLevel': 'NONE',
         }
 
@@ -1028,7 +1029,7 @@ class ApiConfigTest(unittest.TestCase):
       self.assertEqual(cls.api_info.hostname, 'example.appspot.com')
       self.assertIsNone(cls.api_info.audiences)
       self.assertEqual(cls.api_info.allowed_client_ids,
-                       [api_config.API_EXPLORER_CLIENT_ID])
+                       [API_EXPLORER_CLIENT_ID])
       self.assertEqual(cls.api_info.scopes, [api_config.EMAIL_SCOPE])
 
     # Get the config for the combination of all 3.
@@ -1167,7 +1168,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service1.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1177,7 +1178,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service2.list',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1303,7 +1304,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service1.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1313,7 +1314,7 @@ class ApiConfigTest(unittest.TestCase):
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service2.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1370,7 +1371,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'autoTemplate(backendResponse)',
                          'bodyName': 'resource'},
             'rosyMethod': 'Service1.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1388,7 +1389,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'autoTemplate(backendResponse)',
                          'bodyName': 'resource'},
             'rosyMethod': 'Service2.get',
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
             'authLevel': 'NONE',
             },
@@ -1639,7 +1640,7 @@ class ApiConfigTest(unittest.TestCase):
         'response': {'body': 'empty'},
         'rosyMethod': 'MyService.items_update',
         'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-        'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+        'clientIds': [API_EXPLORER_CLIENT_ID],
         'authLevel': 'NONE',
         }
 
@@ -1686,7 +1687,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'empty'},
             'rosyMethod': 'MyService.items_get',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'NONE',
             }
         }
@@ -1722,7 +1723,7 @@ class ApiConfigTest(unittest.TestCase):
             'response': {'body': 'empty'},
             'rosyMethod': 'MyService.items_get',
             'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-            'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+            'clientIds': [API_EXPLORER_CLIENT_ID],
             'authLevel': 'REQUIRED',
             }
         }
@@ -1989,7 +1990,7 @@ class ApiDecoratorTest(unittest.TestCase):
     self.assertEqual('Cool Service Name', api_info.canonical_name)
     self.assertIsNone(api_info.audiences)
     self.assertEqual([api_config.EMAIL_SCOPE], api_info.scopes)
-    self.assertEqual([api_config.API_EXPLORER_CLIENT_ID],
+    self.assertEqual([API_EXPLORER_CLIENT_ID],
                      api_info.allowed_client_ids)
     self.assertEqual(AUTH_LEVEL.NONE, api_info.auth_level)
     self.assertEqual(None, api_info.resource_name)
@@ -2306,7 +2307,7 @@ class MethodDecoratorTest(unittest.TestCase):
         'scopes', 'scopes',
         ['https://www.googleapis.com/auth/userinfo.email'])
     self.TryListAttributeVariations('allowed_client_ids', 'clientIds',
-                                    [api_config.API_EXPLORER_CLIENT_ID])
+                                    [API_EXPLORER_CLIENT_ID])
 
   def TryListAttributeVariations(self, attribute_name, config_name,
                                  default_expected):
@@ -2365,7 +2366,7 @@ class MethodDecoratorTest(unittest.TestCase):
               'response': {'body': 'empty'},
               'rosyMethod': 'AuthServiceImpl.baz',
               'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
-              'clientIds': [api_config.API_EXPLORER_CLIENT_ID],
+              'clientIds': [API_EXPLORER_CLIENT_ID],
               'authLevel': 'NONE'
               }
           }

--- a/endpoints/test/users_id_token_test.py
+++ b/endpoints/test/users_id_token_test.py
@@ -31,6 +31,7 @@ from protorpc import remote
 
 import test_util
 import endpoints.users_id_token as users_id_token
+import endpoints.constants as constants
 
 from google.appengine.api import memcache
 from google.appengine.api import oauth
@@ -412,7 +413,7 @@ class UsersIdTokenTest(UsersIdTokenTestBase):
     self.assertOauthSucceeded(self._SAMPLE_ALLOWED_CLIENT_IDS[0])
 
   def testOauthExplorerClientId(self):
-    self.assertOauthFailed(api_config.API_EXPLORER_CLIENT_ID)
+    self.assertOauthFailed(constants.API_EXPLORER_CLIENT_ID)
 
   def testOauthInvalidScope(self):
     self.assertOauthFailed(None)
@@ -615,7 +616,7 @@ class UsersIdTokenTestWithSimpleApi(UsersIdTokenTestBase):
         self._SAMPLE_TOKEN,
         users_id_token._ISSUERS,
         self._SAMPLE_AUDIENCES,
-        self._SAMPLE_ALLOWED_CLIENT_IDS,
+        (constants.API_EXPLORER_CLIENT_ID,) + self._SAMPLE_ALLOWED_CLIENT_IDS,
         1001,
         memcache,
       )
@@ -660,7 +661,7 @@ class UsersIdTokenTestWithSimpleApi(UsersIdTokenTestBase):
     os.environ['HTTP_AUTHORIZATION'] = 'Bearer ' + dummy_token
     api_instance.method(message_types.VoidMessage())
     self.assertEqual(os.getenv('ENDPOINTS_USE_OAUTH_SCOPE'), dummy_scope)
-    mock_local.assert_called_once_with()
+    mock_local.assert_has_calls([mock.call(), mock.call()])
     mock_get_client_id.assert_called_once_with(dummy_scope)
 
   @mock.patch.object(users_id_token, '_get_id_token_user')
@@ -690,7 +691,7 @@ class UsersIdTokenTestWithSimpleApi(UsersIdTokenTestBase):
         self._SAMPLE_TOKEN,
         users_id_token._ISSUERS,
         self._SAMPLE_AUDIENCES,
-        self._SAMPLE_ALLOWED_CLIENT_IDS,
+        (constants.API_EXPLORER_CLIENT_ID,) + self._SAMPLE_ALLOWED_CLIENT_IDS,
         1001,
         memcache)
     mock_get_id_token_user.reset_mock()
@@ -706,7 +707,7 @@ class UsersIdTokenTestWithSimpleApi(UsersIdTokenTestBase):
         self._SAMPLE_TOKEN,
         users_id_token._ISSUERS,
         self._SAMPLE_AUDIENCES,
-        self._SAMPLE_ALLOWED_CLIENT_IDS,
+        (constants.API_EXPLORER_CLIENT_ID,) + self._SAMPLE_ALLOWED_CLIENT_IDS,
         1001,
         memcache)
 

--- a/endpoints/users_id_token.py
+++ b/endpoints/users_id_token.py
@@ -30,6 +30,8 @@ import urllib
 from collections import Container as _Container, Iterable as _Iterable
 import attr
 
+import constants
+
 from google.appengine.api import memcache
 from google.appengine.api import oauth
 from google.appengine.api import urlfetch
@@ -50,9 +52,9 @@ except ImportError:
 
 
 __all__ = [
+    'convert_jwks_uri',
     'get_current_user',
     'get_verified_jwt',
-    'convert_jwks_uri',
     'InvalidGetUserCall',
     'SKIP_CLIENT_ID_CHECK',
 ]
@@ -201,6 +203,9 @@ def _maybe_set_current_user_vars(method, api_info=None, request=None):
   token = _get_token(request)
   if not token:
     return None
+
+  if allowed_client_ids and _is_local_dev():
+    allowed_client_ids = (constants.API_EXPLORER_CLIENT_ID,) + tuple(allowed_client_ids)
 
   # When every item in the acceptable scopes list is
   # "https://www.googleapis.com/auth/userinfo.email", and there is a non-empty


### PR DESCRIPTION
#92 broke master when merged in, so I reverted the merge. Going to leave this open while I explore what's going on; the `mox` errors are not easy to read.