### PR TITLE
Replace the obsolete mox library with mock.

### DIFF
--- a/endpoints/api_backend.py
+++ b/endpoints/api_backend.py
@@ -58,6 +58,8 @@ class LogMessagesRequest(messages.Message):
       critical = logging.CRITICAL
 
     level = messages.EnumField(Level, 1)
+    # message value is silently ignored if it's a bytestring
+    # make sure it is a unicode string!
     message = messages.StringField(2, required=True)
 
   messages = messages.MessageField(LogMessage, 1, repeated=True)

--- a/endpoints/test/apiserving_test.py
+++ b/endpoints/test/apiserving_test.py
@@ -31,7 +31,6 @@ import endpoints.api_backend_service as api_backend_service
 import endpoints.api_config as api_config
 import endpoints.api_exceptions as api_exceptions
 import endpoints.apiserving as apiserving
-import mox
 from protorpc import message_types
 from protorpc import messages
 from protorpc import protojson

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     scripts=['endpoints/endpointscfg.py'],
-    tests_require=['mox', 'protobuf', 'protorpc', 'pytest', 'webtest'],
+    tests_require=['mock', 'protobuf', 'protorpc', 'pytest', 'webtest'],
     install_requires=install_requires,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 appengine-sdk>=1.9.36,<2.0
-mox>=0.5.3,<0.6
 mock>=1.3.0
 pytest>=2.8.3
 pytest-cov>=1.8.1


### PR DESCRIPTION
https://pypi.python.org/pypi/mox urges this transition.

While doing the conversion, I uncovered a few situations where mox was inadequate to detect problems (particularly having to do with the LogMessage class).