### PR TITLE
Peg attrs library at 17.2.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-attrs>=17.2.0
+attrs==17.2.0
 google-endpoints-api-management>=1.2.1
 setuptools>=36.2.5

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open('endpoints/__init__.py', 'r') as f:
         raise RuntimeError("No version number found!")
 
 install_requires = [
-    'attrs>=17.2.0',
+    'attrs==17.2.0',
     'google-endpoints-api-management>=1.2.1',
     'setuptools>=36.2.5',
 ]


### PR DESCRIPTION
17.3.0 introduces use of the standard library module ctypes, which is
not permitted by the App Engine sandbox. See #118.