### PR TITLE
Bump subminor version (2.4.4 -> 2.4.5)

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -33,4 +33,4 @@ from .users_id_token import get_current_user, get_verified_jwt, convert_jwks_uri
 from .users_id_token import InvalidGetUserCall
 from .users_id_token import SKIP_CLIENT_ID_CHECK
 
-__version__ = '2.4.4'
+__version__ = '2.4.5'


### PR DESCRIPTION
Fixes tests for versions of Python where logging.debug() was calling time.time().
Adds extra imports to the base endpoints package.