### PR TITLE
Logger configuration

### DIFF
--- a/endpoints/_endpointscfg_impl.py
+++ b/endpoints/_endpointscfg_impl.py
@@ -51,6 +51,7 @@ except ImportError:
   # If we can't find json packaged with Python import simplejson, which is
   # packaged with the SDK.
   import simplejson as json
+import logging
 import os
 import re
 import sys
@@ -614,6 +615,11 @@ def _SetupStubs():
 
 
 def main(argv):
+  logging.basicConfig()
+  # silence warnings from endpoints.apiserving; they're not relevant
+  # to command-line operation.
+  logging.getLogger('endpoints.apiserving').setLevel(logging.ERROR)
+
   _SetupStubs()
 
   parser = MakeParser(argv[0])

--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -58,6 +58,7 @@ from . import constants
 from google.appengine.api import app_identity
 
 
+_logger = logging.getLogger(__name__)
 package = 'google.appengine.endpoints'
 
 
@@ -1753,10 +1754,11 @@ class ApiConfigGenerator(object):
 
     if not isinstance(message_type, resource_container.ResourceContainer):
       if path_parameter_dict:
-        logging.warning('Method %s specifies path parameters but you are not '
-                        'using a ResourceContainer This will fail in future '
-                        'releases; please switch to using ResourceContainer as '
-                        'soon as possible.', method_id)
+        _logger.warning('Method %s specifies path parameters but you are not '
+                        'using a ResourceContainer; instead, you are using %r. '
+                        'This will fail in future releases; please switch to '
+                        'using ResourceContainer as soon as possible.',
+                        method_id, type(message_type))
       return self.__params_descriptor_without_container(
           message_type, request_kind, path)
 

--- a/endpoints/directory_list_generator.py
+++ b/endpoints/directory_list_generator.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 
 import collections
 import json
-import logging
 import re
 import urlparse
 

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -30,6 +30,7 @@ from . import resource_container
 from . import util
 
 
+_logger = logging.getLogger(__name__)
 _PATH_VARIABLE_PATTERN = r'{([a-zA-Z_][a-zA-Z_.\d]*)}'
 
 _MULTICLASS_MISMATCH_ERROR_TEMPLATE = (
@@ -482,10 +483,11 @@ class DiscoveryGenerator(object):
 
     if request_params_class is None:
       if path_parameter_dict:
-        logging.warning('Method %s specifies path parameters but you are not '
-                        'using a ResourceContainer. This will fail in future '
-                        'releases; please switch to using ResourceContainer as '
-                        'soon as possible.', method_id)
+        _logger.warning('Method %s specifies path parameters but you are not '
+                        'using a ResourceContainer; instead, you are using %r. '
+                        'This will fail in future releases; please switch to '
+                        'using ResourceContainer as soon as possible.',
+                        method_id, type(message_type))
       return self.__params_descriptor_without_container(
           message_type, request_kind, path)
 

--- a/endpoints/discovery_service.py
+++ b/endpoints/discovery_service.py
@@ -25,6 +25,8 @@ from . import directory_list_generator
 from . import discovery_generator
 from . import util
 
+_logger = logging.getLogger(__name__)
+
 
 class DiscoveryService(object):
   """Implements the local discovery service.
@@ -113,7 +115,7 @@ class DiscoveryService(object):
     if not doc:
       error_msg = ('Failed to convert .api to discovery doc for '
                    'version %s of api %s') % (version, api)
-      logging.error('%s', error_msg)
+      _logger.error('%s', error_msg)
       return util.send_wsgi_error_response(error_msg, start_response)
     return self._send_success_response(doc, start_response)
 
@@ -182,7 +184,7 @@ class DiscoveryService(object):
         configs.append(config)
     directory = generator.pretty_print_config_to_json(configs)
     if not directory:
-      logging.error('Failed to get API directory')
+      _logger.error('Failed to get API directory')
       # By returning a 404, code explorer still works if you select the
       # API in the URL
       return util.send_wsgi_not_found_response(start_response)
@@ -209,7 +211,7 @@ class DiscoveryService(object):
       error_msg = ('RPC format documents are no longer supported with the '
                    'Endpoints Framework for Python. Please use the REST '
                    'format.')
-      logging.error('%s', error_msg)
+      _logger.error('%s', error_msg)
       return util.send_wsgi_error_response(error_msg, start_response)
     elif path == self._LIST_API:
       return self._list(request, start_response)

--- a/endpoints/endpoints_dispatcher.py
+++ b/endpoints/endpoints_dispatcher.py
@@ -42,6 +42,9 @@ from . import parameter_converter
 from . import util
 
 
+_logger = logging.getLogger(__name__)
+
+
 __all__ = ['EndpointsDispatcherMiddleware']
 
 _SERVER_SOURCE_IP = '0.2.0.3'
@@ -231,7 +234,7 @@ class EndpointsDispatcherMiddleware(object):
                                        'text/html')],
                                      PROXY_HTML, start_response)
     else:
-      logging.error('Unknown static url requested: %s',
+      _logger.error('Unknown static url requested: %s',
                     request.relative_url)
       return util.send_wsgi_response('404 Not Found', [('Content-Type',
                                        'text/plain')], 'Not Found',

--- a/endpoints/errors.py
+++ b/endpoints/errors.py
@@ -30,6 +30,8 @@ __all__ = ['BackendError',
            'RequestError',
            'RequestRejectionError']
 
+_logger = logging.getLogger(__name__)
+
 _INVALID_ENUM_TEMPLATE = 'Invalid string value: %r. Allowed values: %r'
 _INVALID_BASIC_PARAM_TEMPLATE = 'Invalid %s value: %r.'
 
@@ -247,7 +249,7 @@ class BackendError(RequestError):
     try:
       return int(http_status.split(' ', 1)[0])
     except TypeError:
-      logging.warning('Unable to find status code in HTTP status %r.',
+      _logger.warning('Unable to find status code in HTTP status %r.',
                       http_status)
     return 500
 

--- a/endpoints/openapi_generator.py
+++ b/endpoints/openapi_generator.py
@@ -29,6 +29,8 @@ from . import resource_container
 from . import util
 
 
+_logger = logging.getLogger(__name__)
+
 _PATH_VARIABLE_PATTERN = r'{([a-zA-Z_][a-zA-Z_.\d]*)}'
 
 _MULTICLASS_MISMATCH_ERROR_TEMPLATE = (
@@ -528,10 +530,11 @@ class OpenApiGenerator(object):
 
     if not isinstance(message_type, resource_container.ResourceContainer):
       if path_parameter_dict:
-        logging.warning('Method %s specifies path parameters but you are not '
-                        'using a ResourceContainer. This will fail in future '
-                        'releases; please switch to using ResourceContainer as '
-                        'soon as possible.', method_id)
+        _logger.warning('Method %s specifies path parameters but you are not '
+                        'using a ResourceContainer; instead, you are using %r. '
+                        'This will fail in future releases; please switch to '
+                        'using ResourceContainer as soon as possible.',
+                        method_id, type(message_type))
       return self.__params_descriptor_without_container(
           message_type, request_kind, method_id, path)
 

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -16,7 +16,6 @@
 
 import itertools
 import json
-import logging
 import unittest
 
 import endpoints.api_config as api_config
@@ -1594,9 +1593,9 @@ class ApiConfigTest(unittest.TestCase):
 
     # Verify that there's a warning and the name of the method is included
     # in the warning.
-    logging.warning = mock.Mock()
+    api_config._logger.warning = mock.Mock()
     self.generator.pretty_print_config_to_json(MyApi)
-    logging.warning.assert_called_with(mock.ANY, 'myapi.test')
+    api_config._logger.warning.assert_called_with(mock.ANY, 'myapi.test', TestGetRequest)
 
   def testFieldInPathWithBodyIsRequired(self):
 


### PR DESCRIPTION
Sets up a basic logger configuration (but silences certain warnings) when running endpointscfg.py

Also use named loggers everywhere, and adds a bit more detail to the ResourceContainer warning to help diagnose instances where it appears unexpectedly.