### PR TITLE
API versioning improvements

### DIFF
--- a/endpoints/_endpointscfg_impl.py
+++ b/endpoints/_endpointscfg_impl.py
@@ -192,7 +192,7 @@ def GenApiConfig(service_class_names, config_string_generator=None,
 
   for resolved_service in resolved_services:
     services = api_service_map.setdefault(
-        (resolved_service.api_info.name, resolved_service.api_info.version), [])
+        (resolved_service.api_info.name, resolved_service.api_info.api_version), [])
     services.append(resolved_service)
 
   # If hostname isn't specified in the API or on the command line, we'll

--- a/endpoints/api_config_manager.py
+++ b/endpoints/api_config_manager.py
@@ -25,6 +25,7 @@ import urllib
 
 from . import discovery_service
 
+_logger = logging.getLogger(__name__)
 
 # Internal constants
 _PATH_VARIABLE_PATTERN = r'[a-zA-Z_][a-zA-Z_.\d]*'
@@ -210,7 +211,7 @@ class ApiConfigManager(object):
           if method:
             break
       else:
-        logging.warn('No endpoint found for path: %s', path)
+        _logger.warn('No endpoint found for path: %s', path)
         method_name = None
         method = None
         params = None

--- a/endpoints/api_config_manager.py
+++ b/endpoints/api_config_manager.py
@@ -68,12 +68,14 @@ class ApiConfigManager(object):
 
       for config in self._configs.itervalues():
         name = config.get('name', '')
-        version = config.get('version', '')
+        api_version = config.get('api_version', '')
+        path_version = config.get('path_version', '')
         sorted_methods = self._get_sorted_methods(config.get('methods', {}))
 
+
         for method_name, method in sorted_methods:
-          self._save_rpc_method(method_name, version, method)
-          self._save_rest_method(method_name, name, version, method)
+          self._save_rpc_method(method_name, api_version, method)
+          self._save_rest_method(method_name, name, path_version, method)
 
   def _get_sorted_methods(self, methods):
     """Get a copy of 'methods' sorted the way they would be on the live server.

--- a/endpoints/api_request.py
+++ b/endpoints/api_request.py
@@ -26,6 +26,8 @@ import zlib
 
 from . import util
 
+_logger = logging.getLogger(__name__)
+
 
 class ApiRequest(object):
   """Simple data object representing an API request.
@@ -90,12 +92,12 @@ class ApiRequest(object):
     # list and record the fact that we're processing a batch.
     if isinstance(self.body_json, list):
       if len(self.body_json) != 1:
-        logging.warning('Batch requests with more than 1 element aren\'t '
+        _logger.warning('Batch requests with more than 1 element aren\'t '
                         'supported in devappserver2.  Only the first element '
                         'will be handled.  Found %d elements.',
                         len(self.body_json))
       else:
-        logging.info('Converting batch request to single request.')
+        _logger.info('Converting batch request to single request.')
       self.body_json = self.body_json[0]
       self.body = json.dumps(self.body_json)
       self._is_batch = True

--- a/endpoints/apiserving.py
+++ b/endpoints/apiserving.py
@@ -295,7 +295,7 @@ class _ApiServer(object):
         service_class = service_factory
         service_factory = service_class.new_factory()
 
-      key = service_class.api_info.name, service_class.api_info.version
+      key = service_class.api_info.name, service_class.api_info.api_version
       service_factories = api_name_version_map.setdefault(key, [])
       if service_factory in service_factories:
         raise api_config.ApiConfigurationError(

--- a/endpoints/directory_list_generator.py
+++ b/endpoints/directory_list_generator.py
@@ -75,7 +75,7 @@ class DirectoryListGenerator(object):
     description = config.get('description')
     root_url = config.get('root')
     name = config.get('name')
-    version = config.get('version')
+    version = config.get('api_version')
     relative_path = '/apis/{0}/{1}/rest'.format(name, version)
 
     if description:

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -831,7 +831,7 @@ class DiscoveryGenerator(object):
       raise api_exceptions.ApiConfigurationError(
           'Multiple base_paths found: {!r}'.format(base_paths))
     names_versions = sorted(set(
-        (s.api_info.name, s.api_info.version) for s in services))
+        (s.api_info.name, s.api_info.api_version) for s in services))
     if len(names_versions) != 1:
       raise api_exceptions.ApiConfigurationError(
           'Multiple apis/versions found: {!r}'.format(names_versions))
@@ -962,21 +962,21 @@ class DiscoveryGenerator(object):
                             util.is_running_on_devserver()) else 'https'
     full_base_path = '{0}{1}/{2}/'.format(api_info.base_path,
                                           api_info.name,
-                                          api_info.version)
+                                          api_info.path_version)
     base_url = '{0}://{1}{2}'.format(protocol, hostname, full_base_path)
     root_url = '{0}://{1}{2}'.format(protocol, hostname, api_info.base_path)
     defaults = {
         'kind': 'discovery#restDescription',
         'discoveryVersion': 'v1',
-        'id': '{0}:{1}'.format(api_info.name, api_info.version),
+        'id': '{0}:{1}'.format(api_info.name, api_info.path_version),
         'name': api_info.name,
-        'version': api_info.version,
+        'version': api_info.api_version,
         'icons': {
             'x16': 'http://www.google.com/images/icons/product/search-16.gif',
             'x32': 'http://www.google.com/images/icons/product/search-32.gif'
         },
         'protocol': 'rest',
-        'servicePath': '{0}/{1}/'.format(api_info.name, api_info.version),
+        'servicePath': '{0}/{1}/'.format(api_info.name, api_info.path_version),
         'batchPath': 'batch',
         'basePath': full_base_path,
         'rootUrl': root_url,

--- a/endpoints/discovery_service.py
+++ b/endpoints/discovery_service.py
@@ -48,6 +48,8 @@ class DiscoveryService(object):
   API_CONFIG = {
       'name': 'discovery',
       'version': 'v1',
+      'api_version': 'v1',
+      'path_version': 'v1',
       'methods': {
           'discovery.apis.getRest': {
               'path': 'apis/{api}/{version}/rest',
@@ -110,7 +112,7 @@ class DiscoveryService(object):
 
     generator = discovery_generator.DiscoveryGenerator(request=request)
     services = [s for s in self._backend.api_services if
-                s.api_info.name == api and s.api_info.version == version]
+                s.api_info.name == api and s.api_info.api_version == version]
     doc = generator.pretty_print_config_to_json(services)
     if not doc:
       error_msg = ('Failed to convert .api to discovery doc for '

--- a/endpoints/openapi_generator.py
+++ b/endpoints/openapi_generator.py
@@ -841,7 +841,7 @@ class OpenApiGenerator(object):
       if not merged_api_info.is_same_api(service.api_info):
         raise api_exceptions.ApiConfigurationError(
             _MULTICLASS_MISMATCH_ERROR_TEMPLATE % (service.api_info.name,
-                                                   service.api_info.version))
+                                                   service.api_info.api_version))
 
     return merged_api_info
 
@@ -893,7 +893,7 @@ class OpenApiGenerator(object):
         method_id = method_info.method_id(service.api_info)
         is_api_key_required = method_info.is_api_key_required(service.api_info)
         path = '/{0}/{1}/{2}'.format(merged_api_info.name,
-                                     merged_api_info.version,
+                                     merged_api_info.path_version,
                                      method_info.get_path(service.api_info))
         verb = method_info.http_method.lower()
 
@@ -977,7 +977,7 @@ class OpenApiGenerator(object):
     defaults = {
         'swagger': '2.0',
         'info': {
-            'version': api_info.version,
+            'version': api_info.api_version,
             'title': api_info.name
         },
         'host': hostname,

--- a/endpoints/test/api_config_manager_test.py
+++ b/endpoints/test/api_config_manager_test.py
@@ -44,6 +44,8 @@ class ApiConfigManagerTest(unittest.TestCase):
                    'rosyMethod': 'baz.bim'}
     config = {'name': 'guestbook_api',
               'version': 'X',
+              'api_version': 'X',
+              'path_version': 'X',
               'methods': {'guestbook_api.foo.bar': fake_method}}
     self.config_manager.process_api_config_response({'items': [config]})
     actual_method = self.config_manager.lookup_rpc_method(
@@ -65,6 +67,8 @@ class ApiConfigManagerTest(unittest.TestCase):
       methods[method_name] = method
     config = {'name': 'guestbook_api',
               'version': 'X',
+              'api_version': 'X',
+              'path_version': 'X',
               'methods': methods}
     self.config_manager.process_api_config_response(
         {'items': [config]})
@@ -151,6 +155,8 @@ class ApiConfigManagerTest(unittest.TestCase):
     """Test that the parsed API config has switched HTTPS to HTTP."""
     config = {'name': 'guestbook_api',
               'version': 'X',
+              'api_version': 'X',
+              'path_version': 'X',
               'adapter': {'bns': 'https://localhost/_ah/spi',
                           'type': 'lily'},
               'root': 'https://localhost/_ah/api',

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -988,7 +988,7 @@ class ApiConfigTest(unittest.TestCase):
   def testMultipleClassesSingleApi(self):
     """Test an API that's split into multiple classes."""
 
-    root_api = api_config.api('root', 'v1', hostname='example.appspot.com')
+    root_api = api_config.api('root', '1.5.6', hostname='example.appspot.com')
 
     # First class has a request that reads some arguments.
     class Response1(messages.Message):
@@ -1024,7 +1024,8 @@ class ApiConfigTest(unittest.TestCase):
     # properties are accessible.
     for cls in (RequestService, EmptyService, MySimpleService):
       self.assertEqual(cls.api_info.name, 'root')
-      self.assertEqual(cls.api_info.version, 'v1')
+      self.assertEqual(cls.api_info.api_version, '1.5.6')
+      self.assertEqual(cls.api_info.path_version, 'v1')
       self.assertEqual(cls.api_info.hostname, 'example.appspot.com')
       self.assertIsNone(cls.api_info.audiences)
       self.assertEqual(cls.api_info.allowed_client_ids,
@@ -1983,7 +1984,8 @@ class ApiDecoratorTest(unittest.TestCase):
 
     api_info = MyDecoratedService.api_info
     self.assertEqual('CoolService', api_info.name)
-    self.assertEqual('vX', api_info.version)
+    self.assertEqual('vX', api_info.api_version)
+    self.assertEqual('vX', api_info.path_version)
     self.assertEqual('My Cool Service', api_info.description)
     self.assertEqual('myhost.com', api_info.hostname)
     self.assertEqual('Cool Service Name', api_info.canonical_name)
@@ -2007,7 +2009,8 @@ class ApiDecoratorTest(unittest.TestCase):
 
     api_info = MyDecoratedService.api_info
     self.assertEqual('CoolService2', api_info.name)
-    self.assertEqual('v2', api_info.version)
+    self.assertEqual('v2', api_info.api_version)
+    self.assertEqual('v2', api_info.path_version)
     self.assertEqual(None, api_info.description)
     self.assertEqual(None, api_info.hostname)
     self.assertEqual(None, api_info.canonical_name)

--- a/endpoints/test/apiserving_test.py
+++ b/endpoints/test/apiserving_test.py
@@ -190,7 +190,9 @@ TEST_SERVICE_API_CONFIG = {'items': [{
     },
     'name': 'testapi',
     'root': 'https://None/_ah/api',
-    'version': 'v3'
+    'version': 'v3',
+    'api_version': 'v3',
+    'path_version': 'v3',
 }]}
 
 
@@ -242,7 +244,9 @@ TEST_SERVICE_CUSTOM_URL_API_CONFIG = {'items': [{
     },
     'name': 'testapicustomurl',
     'root': 'https://None/my/base/path',
-    'version': 'v3'
+    'version': 'v3',
+    'api_version': 'v3',
+    'path_version': 'v3',
 }]}
 
 

--- a/endpoints/test/directory_list_generator_test.py
+++ b/endpoints/test/directory_list_generator_test.py
@@ -37,6 +37,8 @@ _LIST_API = 'apisdev.list'
 API_CONFIG = {
     'name': 'discovery',
     'version': 'v1',
+    'api_version': 'v1',
+    'path_version': 'v1',
     'methods': {
         'discovery.apis.getRest': {
             'path': 'apis/{api}/{version}/rest',

--- a/endpoints/test/discovery_generator_test.py
+++ b/endpoints/test/discovery_generator_test.py
@@ -487,7 +487,7 @@ class DiscoveryUrlGeneratorTest(BaseDiscoveryGeneratorTest):
         iata = messages.StringField(1, required=True)
         name = messages.StringField(2, required=True)
 
-    @api_config.api(name='iata', version='v1')
+    @api_config.api(name='iata', version='1.6.9')
     class IataApi(remote.Service):
         @api_config.method(
             IATA_RESOURCE,

--- a/endpoints/test/openapi_generator_test.py
+++ b/endpoints/test/openapi_generator_test.py
@@ -1339,6 +1339,57 @@ class OpenApiGeneratorTest(BaseOpenApiGeneratorTest):
 
     test_util.AssertDictEqual(expected_openapi, api, self)
 
+  def testSemverVersion(self):
+
+    @api_config.api(name='root', hostname='example.appspot.com', version='1.3.4')
+    class MyService(remote.Service):
+      """Describes MyService."""
+
+      @api_config.method(message_types.VoidMessage, message_types.VoidMessage,
+                         path='noop', http_method='GET', name='noop')
+      def noop_get(self, unused_request):
+        return message_types.VoidMessage()
+
+    api = json.loads(self.generator.pretty_print_config_to_json(MyService))
+
+    expected_openapi = {
+        'swagger': '2.0',
+        'info': {
+            'title': 'root',
+            'description': 'Describes MyService.',
+            'version': '1.3.4',
+        },
+        'host': 'example.appspot.com',
+        'consumes': ['application/json'],
+        'produces': ['application/json'],
+        'schemes': ['https'],
+        'basePath': '/_ah/api',
+        'paths': {
+            '/root/v1/noop': {
+                'get': {
+                    'operationId': 'MyService_noopGet',
+                    'parameters': [],
+                    'responses': {
+                        '200': {
+                            'description': 'A successful response',
+                        },
+                    },
+                },
+            },
+        },
+        'securityDefinitions': {
+            'google_id_token': {
+                'authorizationUrl': '',
+                'flow': 'implicit',
+                'type': 'oauth2',
+                "x-google-issuer": "https://accounts.google.com",
+                "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+            },
+        },
+    }
+
+    assert api == expected_openapi
+
   def testCustomUrl(self):
 
     @api_config.api(name='root', hostname='example.appspot.com', version='v1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 attrs==17.2.0
 google-endpoints-api-management>=1.4.0
+semver==2.7.7
 setuptools>=36.2.5

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ with open('endpoints/__init__.py', 'r') as f:
 install_requires = [
     'attrs==17.2.0',
     'google-endpoints-api-management>=1.4.0',
+    'semver==2.7.7',
     'setuptools>=36.2.5',
 ]
 


### PR DESCRIPTION
Instead of using the same value for the API version as a whole and the version that appears in paths, we will now treat the values separately.

If the user specifies a [semver](https://semver.org/)-compatible version string, such as `2.2.9`, we will extract the major version and place it in paths as `v2`. If the version string is not semver-compatible, it will be placed in paths as-is.

In the future, we may allow users to specify these values separately, but we currently do not.

This will be considered breaking behavior (as it's possible, though unlikely, some people are already using semver-compatible version strings) and will require a new major version of the framework when released.