### PR TITLE
Allow opt-in to new api name restrictions.

### DIFF
--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -258,17 +258,6 @@ def _CheckLimitDefinitions(limit_definitions):
       _CheckType(ld.default_limit, int, 'limit_definition.default_limit')
 
 
-_VALID_API_NAME = re.compile('^[a-z][a-z0-9]{0,39}$')
-
-
-def _CheckApiName(name):
-  valid = (_VALID_API_NAME.match(name) is not None)
-  if not valid:
-    raise api_exceptions.InvalidApiNameException(
-        'The API name must match the regular expression {}'.format(
-            _VALID_API_NAME.pattern[1:-1]))
-
-
 # pylint: disable=g-bad-name
 class _ApiInfo(object):
   """Configurable attributes of an API.
@@ -592,7 +581,6 @@ class _ApiDecorator(object):
         limit_definitions: list of LimitDefinition tuples used in this API.
       """
       _CheckType(name, basestring, 'name', allow_none=False)
-      _CheckApiName(name)
       _CheckType(version, basestring, 'version', allow_none=False)
       _CheckType(description, basestring, 'description')
       _CheckType(hostname, basestring, 'hostname')

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -17,7 +17,6 @@
 import itertools
 import json
 import unittest
-import pytest
 
 import endpoints.api_config as api_config
 from endpoints.api_config import ApiConfigGenerator
@@ -2109,28 +2108,6 @@ class ApiDecoratorTest(unittest.TestCase):
 
     self.assertEqual([MyDecoratedService1, MyDecoratedService2,
                       MyDecoratedService3], my_api.get_api_classes())
-
-  def testApiNameRestrictions(self):
-
-    @api_config.api(name='coolservice', version='vX')
-    class MyDecoratedService(remote.Service):
-      """Describes MyDecoratedService."""
-      pass
-
-    api_info = MyDecoratedService.api_info
-    assert 'coolservice' == api_info.name
-
-    with pytest.raises(api_exceptions.InvalidApiNameException):
-      @api_config.api('CoolService2', 'v2')
-      class MyDecoratedService(remote.Service):
-        """Describes MyDecoratedService."""
-        pass
-
-    with pytest.raises(api_exceptions.InvalidApiNameException):
-      @api_config.api('c' + 'o'*40 + 'l', 'v2')
-      class MyDecoratedService(remote.Service):
-        """Describes MyDecoratedService."""
-        pass
 
 class MethodDecoratorTest(unittest.TestCase):
 


### PR DESCRIPTION
Now the new limitation is enforced only at openapi generation time, and only if the user specifies `--x-google-api-name` on the command line.