### PR TITLE
Revert "Make trailing slash truly optional."

### DIFF
--- a/endpoints/api_config_manager.py
+++ b/endpoints/api_config_manager.py
@@ -317,11 +317,7 @@ class ApiConfigManager(object):
 
     pattern = re.sub('(/|^){(%s)}(?=/|$|:)' % _PATH_VARIABLE_PATTERN,
                      replace_variable, pattern)
-    if pattern.endswith('/'):
-      pattern += '?$'
-    else:
-      pattern += '/?$'
-    return re.compile(pattern)
+    return re.compile(pattern + '/?$')
 
   def _save_rpc_method(self, method_name, version, method):
     """Store JsonRpc api methods in a map for lookup at call time.

--- a/endpoints/test/api_config_manager_test.py
+++ b/endpoints/test/api_config_manager_test.py
@@ -264,26 +264,6 @@ class ApiConfigManagerTest(unittest.TestCase):
     self.assertEqual(fake_method, method_spec)
     self.assertEqual({}, params)
 
-  def test_trailing_slash_could_be_omitted(self):
-    # Create a get resource URL with trailing slash.
-    fake_method = {'httpMethod': 'GET', 'path': 'with-trailing-slash/'}
-    self.config_manager._save_rest_method('guestbook_api.withtrailingslash',
-                                          'guestbook_api', 'v1', fake_method)
-
-    # Make sure we get the method when we query with a slash.
-    method_name, method_spec, params = self.config_manager.lookup_rest_method(
-        'guestbook_api/v1/with-trailing-slash/', 'GET')
-    self.assertEqual('guestbook_api.withtrailingslash', method_name)
-    self.assertEqual(fake_method, method_spec)
-    self.assertEqual({}, params)
-
-    # Make sure we get the method when we query without a slash.
-    method_name, method_spec, params = self.config_manager.lookup_rest_method(
-        'guestbook_api/v1/with-trailing-slash', 'GET')
-    self.assertEqual('guestbook_api.withtrailingslash', method_name)
-    self.assertEqual(fake_method, method_spec)
-    self.assertEqual({}, params)
-
 
 class ParameterizedPathTest(unittest.TestCase):
 


### PR DESCRIPTION
This reverts commit 818c9252583fcdf3f3896dc5d2f7dc43ecd48f36.

Reverted because the author told me he'd found this produces parsing issues:

> It seems now patterns like /prefix/{var1}/{var2}/ and /prefix/{var1}/ are mixed up.

May reconsider this approach later.

This reverts #143 and reopens #142.