### PR TITLE
Support matching path against REQUEST_URI (flag-enabled)

### DIFF
--- a/endpoints/api_request.py
+++ b/endpoints/api_request.py
@@ -50,6 +50,9 @@ class ApiRequest(object):
     self.server = environ['SERVER_NAME']
     self.port = environ['SERVER_PORT']
     self.path = environ['PATH_INFO']
+    self.request_uri = environ.get('REQUEST_URI')
+    if self.request_uri is not None and len(self.request_uri) < len(self.path):
+      self.request_uri = None
     self.query = environ.get('QUERY_STRING')
     self.body = environ['wsgi.input'].read()
     if self.body and self.headers.get('CONTENT-ENCODING') == 'gzip':
@@ -74,6 +77,8 @@ class ApiRequest(object):
     for base_path in base_paths:
       if self.path.startswith(base_path):
         self.path = self.path[len(base_path):]
+        if self.request_uri is not None:
+          self.request_uri = self.request_uri[len(base_path):]
         self.base_path = base_path
         break
     else:

--- a/endpoints/endpoints_dispatcher.py
+++ b/endpoints/endpoints_dispatcher.py
@@ -484,7 +484,7 @@ class EndpointsDispatcherMiddleware(object):
       was found for the current request.
     """
     method_name, method, params = self.config_manager.lookup_rest_method(
-        orig_request.path, orig_request.http_method)
+        orig_request.path, orig_request.request_uri, orig_request.http_method)
     orig_request.method_name = method_name
     return method, params
 

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -212,6 +212,7 @@ class ApiConfigTest(unittest.TestCase):
             'description': 'All field types in the query parameters.',
             'httpMethod': 'GET',
             'path': 'entries',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty',
                 'parameters': {
@@ -285,6 +286,7 @@ class ApiConfigTest(unittest.TestCase):
             'description': 'All field types in the query parameters.',
             'httpMethod': 'GET',
             'path': 'entries/container',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty',
                 'parameters': {
@@ -355,6 +357,7 @@ class ApiConfigTest(unittest.TestCase):
                             'required param.'),
             'httpMethod': 'POST',
             'path': 'entries/container/{entryId}/publish',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource',
@@ -378,6 +381,7 @@ class ApiConfigTest(unittest.TestCase):
             'description': 'Request body is in the body field.',
             'httpMethod': 'POST',
             'path': 'entries',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource'
@@ -394,6 +398,7 @@ class ApiConfigTest(unittest.TestCase):
             'description': 'Message is the request body.',
             'httpMethod': 'POST',
             'path': 'process',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource'
@@ -410,6 +415,7 @@ class ApiConfigTest(unittest.TestCase):
             'description': 'A VoidMessage for a request body.',
             'httpMethod': 'POST',
             'path': 'nested',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty'
                 },
@@ -425,6 +431,7 @@ class ApiConfigTest(unittest.TestCase):
             'description': 'All field types in the request and response.',
             'httpMethod': 'POST',
             'path': 'roundtrip',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource'
@@ -443,6 +450,7 @@ class ApiConfigTest(unittest.TestCase):
             'Path has a parameter and request body has a required param.',
             'httpMethod': 'POST',
             'path': 'entries/{entryId}/publish',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource',
@@ -469,6 +477,7 @@ class ApiConfigTest(unittest.TestCase):
                 'Path has a parameter and request body is in the body field.',
             'httpMethod': 'POST',
             'path': 'entries/{entryId}/items',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource',
@@ -495,6 +504,7 @@ class ApiConfigTest(unittest.TestCase):
                             'the body field.'),
             'httpMethod': 'POST',
             'path': 'entries/container/{entryId}/items',
+            'useRequestUri': False,
             'request': {
                 'body': 'autoTemplate(backendRequest)',
                 'bodyName': 'resource',
@@ -973,6 +983,7 @@ class ApiConfigTest(unittest.TestCase):
         'scopes': ['https://www.googleapis.com/auth/userinfo.email'],
         'clientIds': [API_EXPLORER_CLIENT_ID],
         'authLevel': 'NONE',
+        'useRequestUri': False,
         }
 
     get_container_config = get_config.copy()
@@ -1039,6 +1050,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.request.my_request': {
             'httpMethod': 'GET',
             'path': 'request_path',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {
                 'body': 'autoTemplate(backendResponse)',
@@ -1051,6 +1063,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.simple.entries.get': {
             'httpMethod': 'POST',
             'path': 'entries',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {
                 'body': 'autoTemplate(backendResponse)',
@@ -1165,6 +1178,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.repeated.get': {
             'httpMethod': 'GET',
             'path': 'get',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service1.get',
@@ -1175,6 +1189,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.repeated.list': {
             'httpMethod': 'GET',
             'path': 'list',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service2.list',
@@ -1301,6 +1316,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.resource1.get': {
             'httpMethod': 'GET',
             'path': 'get1',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service1.get',
@@ -1311,6 +1327,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.resource2.get': {
             'httpMethod': 'GET',
             'path': 'get2',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'Service2.get',
@@ -1360,6 +1377,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.resource1.get': {
             'httpMethod': 'GET',
             'path': 'get1',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty',
                 'parameters': {
@@ -1378,6 +1396,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.resource2.get': {
             'httpMethod': 'GET',
             'path': 'get2',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty',
                 'parameters': {
@@ -1457,6 +1476,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.donothing': {
             'httpMethod': 'GET',
             'path': 'donothing',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'TestService.donothing',
@@ -1467,6 +1487,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.alternate': {
             'httpMethod': 'POST',
             'path': 'foo',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'TestService.foo',
@@ -1507,6 +1528,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.at_base': {
             'httpMethod': 'GET',
             'path': 'base_path/at_base',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'TestService.at_base',
@@ -1517,6 +1539,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.append_to_base': {
             'httpMethod': 'GET',
             'path': 'base_path/appended',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'TestService.append_to_base',
@@ -1527,6 +1550,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.append_to_base2': {
             'httpMethod': 'GET',
             'path': 'base_path/appended/more',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'TestService.append_to_base2',
@@ -1537,6 +1561,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.absolute': {
             'httpMethod': 'GET',
             'path': 'ignore_base',
+            'useRequestUri': False,
             'request': {'body': 'empty'},
             'response': {'body': 'empty'},
             'rosyMethod': 'TestService.absolute',
@@ -1633,6 +1658,7 @@ class ApiConfigTest(unittest.TestCase):
     items_update_config = {
         'httpMethod': 'PUT',
         'path': 'items/{itemId}',
+        'useRequestUri': False,
         'request': {'body': 'autoTemplate(backendRequest)',
                     'bodyName': 'resource',
                     'parameters': params,
@@ -1681,6 +1707,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.items.get': {
             'httpMethod': 'GET',
             'path': 'items/{itemId}',
+            'useRequestUri': False,
             'request': {'body': 'empty',
                         'parameters': params,
                         'parameterOrder': param_order},
@@ -1717,6 +1744,7 @@ class ApiConfigTest(unittest.TestCase):
         'root.items.get': {
             'httpMethod': 'GET',
             'path': 'items/{itemId}',
+            'useRequestUri': False,
             'request': {'body': 'empty',
                         'parameters': params,
                         'parameterOrder': param_order},
@@ -2365,6 +2393,7 @@ class MethodDecoratorTest(unittest.TestCase):
           'authservice.baz': {
               'httpMethod': 'POST',
               'path': 'baz',
+              'useRequestUri': False,
               'request': {'body': 'empty'},
               'response': {'body': 'empty'},
               'rosyMethod': 'AuthServiceImpl.baz',

--- a/endpoints/test/apiserving_test.py
+++ b/endpoints/test/apiserving_test.py
@@ -170,6 +170,7 @@ TEST_SERVICE_API_CONFIG = {'items': [{
         'testapi.delete': {
             'httpMethod': 'DELETE',
             'path': 'items/{id}',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty',
                 'parameterOrder': ['id'],
@@ -224,6 +225,7 @@ TEST_SERVICE_CUSTOM_URL_API_CONFIG = {'items': [{
         'testapicustomurl.delete': {
             'httpMethod': 'DELETE',
             'path': 'items/{id}',
+            'useRequestUri': False,
             'request': {
                 'body': 'empty',
                 'parameterOrder': ['id'],

--- a/endpoints/test/integration_test.py
+++ b/endpoints/test/integration_test.py
@@ -1,0 +1,107 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests against fully-constructed apps"""
+
+import pytest
+import webtest
+import urllib
+
+import endpoints
+from protorpc import message_types
+from protorpc import messages
+from protorpc import remote
+
+
+class FileResponse(messages.Message):
+    path = messages.StringField(1)
+    payload = messages.StringField(2)
+
+FILE_RESOURCE = endpoints.ResourceContainer(
+    message_types.VoidMessage,
+    path=messages.StringField(1)
+)
+
+FILES = {
+    u'/': u'4aa7fda4-8853-4946-946e-aab5dada1152',
+    u'foo': u'719eeb0a-de5e-4f17-8ab0-1567974d75c1',
+    u'foo/bar': u'da6e0dfe-8c74-4a46-9696-b08b58e03e79',
+    u'foo/bar/baz/': u'2543e3cf-0ae1-4278-9a76-8d1e2ee90de7',
+    u'/hello': u'80e3d7ee-d289-4aa7-b0ef-eb3a8232f33f',
+}
+
+def _quote_slash(part):
+    return urllib.quote(part, safe='')
+
+def _make_app(api_use, method_use):
+    @endpoints.api(name='filefetcher', version='1.0.0', use_request_uri=api_use)
+    class FileFetcherApi(remote.Service):
+        @endpoints.method(FILE_RESOURCE, FileResponse, path='get_file/{path}',
+                          http_method='GET', name='get_file', use_request_uri=method_use)
+        def get_file(self, request):
+            if request.path not in FILES:
+                raise endpoints.NotFoundException()
+            val = FileResponse(path=request.path, payload=FILES[request.path])
+            return val
+    return webtest.TestApp(endpoints.api_server([FileFetcherApi]), lint=False)
+
+def _make_request(app, url, expect_status):
+    kwargs = {}
+    if expect_status:
+        kwargs['status'] = expect_status
+    return app.get(url, extra_environ={'REQUEST_URI': url}, **kwargs)
+
+
+@pytest.mark.parametrize('api_use,method_use,expect_404', [
+    (True, True, False),
+    (True, False, True),
+    (False, True, False),
+    (False, False, True),
+])
+class TestSlashVariable(object):
+    def test_missing_file(self, api_use, method_use, expect_404):
+        app = _make_app(api_use, method_use)
+        url = '/_ah/api/filefetcher/v1/get_file/missing'
+        # This _should_ return 404, but https://github.com/cloudendpoints/endpoints-python/issues/138
+        # the other methods actually return 404 because protorpc doesn't rewrite it there
+        _make_request(app, url, expect_status=400)
+
+    def test_no_slash(self, api_use, method_use, expect_404):
+        app = _make_app(api_use, method_use)
+        url = '/_ah/api/filefetcher/v1/get_file/foo'
+        _make_request(app, url, expect_status=None)
+
+    def test_mid_slash(self, api_use, method_use, expect_404):
+        app = _make_app(api_use, method_use)
+        url = '/_ah/api/filefetcher/v1/get_file/{}'.format(_quote_slash('foo/bar'))
+        actual = _make_request(app, url, expect_status=404 if expect_404 else 200)
+        if not expect_404:
+            expected = {'path': 'foo/bar', 'payload': 'da6e0dfe-8c74-4a46-9696-b08b58e03e79'}
+            assert actual.json == expected
+
+    def test_ending_slash(self, api_use, method_use, expect_404):
+        app = _make_app(api_use, method_use)
+        url = '/_ah/api/filefetcher/v1/get_file/{}'.format(_quote_slash('foo/bar/baz/'))
+        actual = _make_request(app, url, expect_status=404 if expect_404 else 200)
+        if not expect_404:
+            expected = {'path': 'foo/bar/baz/', 'payload': '2543e3cf-0ae1-4278-9a76-8d1e2ee90de7'}
+            assert actual.json == expected
+
+    def test_beginning_slash(self, api_use, method_use, expect_404):
+        app = _make_app(api_use, method_use)
+        url = '/_ah/api/filefetcher/v1/get_file/{}'.format(_quote_slash('/hello'))
+        actual = _make_request(app, url, expect_status=404 if expect_404 else 200)
+        if not expect_404:
+            expected = {'path': '/hello', 'payload': '80e3d7ee-d289-4aa7-b0ef-eb3a8232f33f'}
+            assert actual.json == expected


### PR DESCRIPTION
In some cases, users may want to match paths against the escaped REQUEST_URI environment variable instead of the PATH_INFO variable. This allows ignoring escaped slashes `%2F` for purposes of path segment splitting.

This behavior must be enabled by using `use_request_uri=True` at the api or method level.