### PR TITLE
Improved 'No endpoint found' message.

### DIFF
--- a/endpoints/api_config_manager.py
+++ b/endpoints/api_config_manager.py
@@ -195,7 +195,7 @@ class ApiConfigManager(object):
           method_name, method = candidate_method_info
           break
       else:
-        _logger.warn('No endpoint found for path: %s', path)
+        _logger.warn('No endpoint found for path: %r, method: %r', path, http_method)
         method_name = None
         method = None
         params = None


### PR DESCRIPTION
This will make it easier to spot 404s caused by requests for a valid path but with the wrong HTTP method.