### PR TITLE
Several discovery document fixes

### DIFF
--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -514,6 +514,7 @@ class DiscoveryGenerator(object):
     Args:
       message_type: messages.Message class, Message with parameters to describe.
       path: string, HTTP path to method.
+      is_params_class: boolean, Whether the message represents URL parameters.
 
     Returns:
       Descriptor list for the parameter order.

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -324,7 +324,7 @@ class DiscoveryGenerator(object):
       if isinstance(field, messages.EnumField):
         return field.default.name
       else:
-        return field.default
+        return str(field.default)
 
   def __parameter_enum(self, param):
     """Returns enum descriptor of a parameter if it is an enum.
@@ -562,6 +562,9 @@ class DiscoveryGenerator(object):
             num_enums = len(prop_value['enum'])
             key_result['properties'][prop_key]['enumDescriptions'] = (
                 [''] * num_enums)
+          elif 'default' in prop_value:
+            # stringify default values
+            prop_value['default'] = str(prop_value['default'])
           key_result['properties'][prop_key].pop('required', None)
 
       for key in ('type', 'id', 'description'):

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -986,7 +986,16 @@ class DiscoveryGenerator(object):
         'basePath': full_base_path,
         'rootUrl': root_url,
         'baseUrl': base_url,
+        'description': 'This is an API',
     }
+    if api_info.description:
+        defaults['description'] = api_info.description
+    if api_info.title:
+        defaults['title'] = api_info.title
+    if api_info.documentation:
+        defaults['documentationLink'] = api_info.documentation
+    if api_info.canonical_name:
+        defaults['canonicalName'] = api_info.canonical_name
 
     return defaults
 

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -977,8 +977,8 @@ class DiscoveryGenerator(object):
         'name': api_info.name,
         'version': api_info.api_version,
         'icons': {
-            'x16': 'http://www.google.com/images/icons/product/search-16.gif',
-            'x32': 'http://www.google.com/images/icons/product/search-32.gif'
+            'x16': 'https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png',
+            'x32': 'https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png'
         },
         'protocol': 'rest',
         'servicePath': '{0}/{1}/'.format(api_info.name, api_info.path_version),

--- a/endpoints/test/discovery_document_test.py
+++ b/endpoints/test/discovery_document_test.py
@@ -1,0 +1,116 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test various discovery docs"""
+
+import json
+import os.path
+
+import pytest
+import webtest
+import urllib
+
+import endpoints
+import endpoints.discovery_generator as discovery_generator
+from protorpc import message_types
+from protorpc import messages
+from protorpc import remote
+
+def make_collection(cls):
+    return type(
+        'Collection_{}'.format(cls.__name__),
+        (messages.Message,),
+        {
+            'items': messages.MessageField(cls, 1, repeated=True),
+            'nextPageToken': messages.StringField(2)
+        })
+
+def load_expected_document(filename):
+    try:
+        pwd = os.path.dirname(os.path.realpath(__file__))
+        test_file = os.path.join(pwd, 'testdata', 'discovery', filename)
+        with open(test_file) as f:
+            return json.loads(f.read())
+    except IOError as e:
+        print 'Could not find expected output file ' + test_file
+        raise e
+
+
+class Foo(messages.Message):
+    name = messages.StringField(1)
+    value = messages.IntegerField(2, variant=messages.Variant.INT32)
+
+FooCollection = make_collection(Foo)
+FooResource = endpoints.ResourceContainer(
+    Foo,
+    id=messages.StringField(1, required=True),
+)
+FooIdResource = endpoints.ResourceContainer(
+    message_types.VoidMessage,
+    id=messages.StringField(1, required=True),
+)
+FooNResource = endpoints.ResourceContainer(
+    message_types.VoidMessage,
+    n = messages.IntegerField(1, required=True, variant=messages.Variant.INT32),
+)
+
+@endpoints.api(
+    name='foo', version='v1', audiences=['audiences'],
+    title='The Foo API', description='Just Foo Things',
+    documentation='https://example.com', canonical_name='CanonicalName')
+class FooEndpoint(remote.Service):
+    @endpoints.method(FooResource, Foo, name='foo.create', path='foos/{id}', http_method='PUT')
+    def createFoo(self, request):
+        pass
+    @endpoints.method(FooIdResource, Foo, name='foo.get', path='foos/{id}', http_method='GET')
+    def getFoo(self, request):
+        pass
+    @endpoints.method(FooResource, Foo, name='foo.update', path='foos/{id}', http_method='POST')
+    def updateFoo(self, request):
+        pass
+    @endpoints.method(FooIdResource, Foo, name='foo.delete', path='foos/{id}', http_method='DELETE')
+    def deleteFoo(self, request):
+        pass
+    @endpoints.method(FooNResource, FooCollection, name='foo.list', path='foos', http_method='GET')
+    def listFoos(self, request):
+        pass
+    @endpoints.method(message_types.VoidMessage, FooCollection, name='toplevel', path='foos', http_method='POST')
+    def toplevel(self, request):
+        pass
+
+
+@endpoints.api(name='multipleparam', version='v1')
+class MultipleParameterEndpoint(remote.Service):
+    @endpoints.method(endpoints.ResourceContainer(
+        message_types.VoidMessage,
+        parent = messages.StringField(1, required=True),
+        query = messages.StringField(2, required=False),
+        child = messages.StringField(3, required=True),
+        queryb = messages.StringField(4, required=True),
+        querya = messages.StringField(5, required=True),
+    ), message_types.VoidMessage, name='param', path='param/{parent}/{child}')
+    def param(self, request):
+        pass
+
+@pytest.mark.parametrize('endpoint, json_filename', [
+    (FooEndpoint, 'foo_endpoint.json'),
+    (MultipleParameterEndpoint, 'multiple_parameter_endpoint.json'),
+])
+def test_discovery(endpoint, json_filename):
+    generator = discovery_generator.DiscoveryGenerator()
+    # JSON roundtrip so we get consistent string types
+    actual = json.loads(generator.pretty_print_config_to_json(
+        [endpoint], hostname='discovery-test.appspot.com'))
+    expected = load_expected_document(json_filename)
+    assert actual == expected

--- a/endpoints/test/discovery_document_test.py
+++ b/endpoints/test/discovery_document_test.py
@@ -90,6 +90,44 @@ class FooEndpoint(remote.Service):
         pass
 
 
+class Bar(messages.Message):
+    name = messages.StringField(1, default='Jimothy')
+    value = messages.IntegerField(2, default=42, variant=messages.Variant.INT32)
+    active = messages.BooleanField(3, default=True)
+
+BarCollection = make_collection(Bar)
+BarResource = endpoints.ResourceContainer(
+    Bar,
+    id=messages.StringField(1, required=True),
+)
+BarIdResource = endpoints.ResourceContainer(
+    message_types.VoidMessage,
+    id=messages.StringField(1, required=True),
+)
+BarNResource = endpoints.ResourceContainer(
+    message_types.VoidMessage,
+    n = messages.IntegerField(1, required=True, variant=messages.Variant.INT32),
+)
+
+@endpoints.api(name='bar', version='v1')
+class BarEndpoint(remote.Service):
+    @endpoints.method(BarResource, Bar, name='bar.create', path='bars/{id}', http_method='PUT')
+    def createBar(self, request):
+        pass
+    @endpoints.method(BarIdResource, Bar, name='bar.get', path='bars/{id}', http_method='GET')
+    def getBar(self, request):
+        pass
+    @endpoints.method(BarResource, Bar, name='bar.update', path='bars/{id}', http_method='POST')
+    def updateBar(self, request):
+        pass
+    @endpoints.method(BarIdResource, Bar, name='bar.delete', path='bars/{id}', http_method='DELETE')
+    def deleteBar(self, request):
+        pass
+    @endpoints.method(BarNResource, BarCollection, name='bar.list', path='bars', http_method='GET')
+    def listBars(self, request):
+        pass
+
+
 @endpoints.api(name='multipleparam', version='v1')
 class MultipleParameterEndpoint(remote.Service):
     @endpoints.method(endpoints.ResourceContainer(
@@ -105,6 +143,7 @@ class MultipleParameterEndpoint(remote.Service):
 
 @pytest.mark.parametrize('endpoint, json_filename', [
     (FooEndpoint, 'foo_endpoint.json'),
+    (BarEndpoint, 'bar_endpoint.json'),
     (MultipleParameterEndpoint, 'multiple_parameter_endpoint.json'),
 ])
 def test_discovery(endpoint, json_filename):

--- a/endpoints/test/testdata/discovery/allfields.json
+++ b/endpoints/test/testdata/discovery/allfields.json
@@ -6,8 +6,8 @@
   "version":"v1",
   "description":"This is an API",
   "icons":{
-    "x16":"http://www.google.com/images/icons/product/search-16.gif",
-    "x32":"http://www.google.com/images/icons/product/search-32.gif"
+    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
   },
   "protocol":"rest",
   "baseUrl":"https://example.appspot.com/_ah/api/root/v1/",

--- a/endpoints/test/testdata/discovery/bar_endpoint.json
+++ b/endpoints/test/testdata/discovery/bar_endpoint.json
@@ -1,0 +1,228 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/_ah/api/bar/v1/",
+  "baseUrl": "https://discovery-test.appspot.com/_ah/api/bar/v1/",
+  "batchPath": "batch",
+  "description": "This is an API",
+  "discoveryVersion": "v1",
+  "icons": {
+    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
+  },
+  "id": "bar:v1",
+  "kind": "discovery#restDescription",
+  "name": "bar",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "resources": {
+    "bar": {
+      "methods": {
+        "create": {
+          "httpMethod": "PUT",
+          "id": "bar.bar.create",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "bars/{id}",
+          "request": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "delete": {
+          "httpMethod": "DELETE",
+          "id": "bar.bar.delete",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "bars/{id}",
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "get": {
+          "httpMethod": "GET",
+          "id": "bar.bar.get",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "bars/{id}",
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "list": {
+          "httpMethod": "GET",
+          "id": "bar.bar.list",
+          "parameterOrder": [
+            "n"
+          ],
+          "parameters": {
+            "n": {
+              "format": "int32",
+              "location": "query",
+              "required": true,
+              "type": "integer"
+            }
+          },
+          "path": "bars",
+          "response": {
+            "$ref": "ProtorpcMessagesCollectionBar"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "update": {
+          "httpMethod": "POST",
+          "id": "bar.bar.update",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "bars/{id}",
+          "request": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        }
+      }
+    }
+  },
+  "rootUrl": "https://discovery-test.appspot.com/_ah/api/",
+  "schemas": {
+    "ProtorpcMessagesCollectionBar": {
+      "id": "ProtorpcMessagesCollectionBar",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestBar"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EndpointsTestDiscoveryDocumentTestBar": {
+      "id": "EndpointsTestDiscoveryDocumentTestBar",
+      "properties": {
+        "name": {
+          "type": "string",
+	  "default": "Jimothy"
+        },
+        "value": {
+          "format": "int32",
+          "type": "integer",
+	  "default": "42"
+        },
+	"active": {
+	  "type": "boolean",
+	  "default": "True"
+	}
+      },
+      "type": "object"
+    }
+  },
+  "servicePath": "bar/v1/",
+  "version": "v1"
+}

--- a/endpoints/test/testdata/discovery/foo_endpoint.json
+++ b/endpoints/test/testdata/discovery/foo_endpoint.json
@@ -1,0 +1,238 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/_ah/api/foo/v1/",
+  "baseUrl": "https://discovery-test.appspot.com/_ah/api/foo/v1/",
+  "batchPath": "batch",
+  "canonicalName": "CanonicalName",
+  "description": "Just Foo Things",
+  "discoveryVersion": "v1",
+  "documentationLink": "https://example.com",
+  "icons": {
+    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
+  },
+  "id": "foo:v1",
+  "kind": "discovery#restDescription",
+  "methods": {
+    "toplevel": {
+      "httpMethod": "POST",
+      "id": "foo.toplevel",
+      "path": "foos",
+      "response": {
+        "$ref": "ProtorpcMessagesCollectionFoo"
+      },
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    }
+  },
+  "name": "foo",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "resources": {
+    "foo": {
+      "methods": {
+        "create": {
+          "httpMethod": "PUT",
+          "id": "foo.foo.create",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "request": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "delete": {
+          "httpMethod": "DELETE",
+          "id": "foo.foo.delete",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "get": {
+          "httpMethod": "GET",
+          "id": "foo.foo.get",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "list": {
+          "httpMethod": "GET",
+          "id": "foo.foo.list",
+          "parameterOrder": [
+            "n"
+          ],
+          "parameters": {
+            "n": {
+              "format": "int32",
+              "location": "query",
+              "required": true,
+              "type": "integer"
+            }
+          },
+          "path": "foos",
+          "response": {
+            "$ref": "ProtorpcMessagesCollectionFoo"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "update": {
+          "httpMethod": "POST",
+          "id": "foo.foo.update",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "request": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        }
+      }
+    }
+  },
+  "rootUrl": "https://discovery-test.appspot.com/_ah/api/",
+  "schemas": {
+    "ProtorpcMessagesCollectionFoo": {
+      "id": "ProtorpcMessagesCollectionFoo",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "EndpointsTestDiscoveryDocumentTestFoo"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EndpointsTestDiscoveryDocumentTestFoo": {
+      "id": "EndpointsTestDiscoveryDocumentTestFoo",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "servicePath": "foo/v1/",
+  "title": "The Foo API",
+  "version": "v1"
+}

--- a/endpoints/test/testdata/discovery/multiple_parameter_endpoint.json
+++ b/endpoints/test/testdata/discovery/multiple_parameter_endpoint.json
@@ -1,0 +1,114 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/_ah/api/multipleparam/v1/",
+  "baseUrl": "https://discovery-test.appspot.com/_ah/api/multipleparam/v1/",
+  "batchPath": "batch",
+  "description": "This is an API",
+  "discoveryVersion": "v1",
+  "icons": {
+    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
+  },
+  "id": "multipleparam:v1",
+  "kind": "discovery#restDescription",
+  "methods": {
+    "param": {
+      "httpMethod": "POST",
+      "id": "multipleparam.param",
+      "parameterOrder": [
+        "parent",
+        "child",
+        "querya",
+        "queryb"
+      ],
+      "parameters": {
+        "parent": {
+          "location": "path",
+          "required": true,
+          "type": "string"
+        },
+        "query": {
+          "location": "query",
+          "type": "string"
+        },
+        "child": {
+          "location": "path",
+          "required": true,
+          "type": "string"
+        },
+        "queryb": {
+          "location": "query",
+          "required": true,
+          "type": "string"
+        },
+        "querya": {
+          "location": "query",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "path": "param/{parent}/{child}",
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    }
+  },
+  "name": "multipleparam",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "rootUrl": "https://discovery-test.appspot.com/_ah/api/",
+  "servicePath": "multipleparam/v1/",
+  "version": "v1"
+}

--- a/endpoints/test/testdata/discovery/namespace.json
+++ b/endpoints/test/testdata/discovery/namespace.json
@@ -9,8 +9,8 @@
   "version":"v1",
   "description":"This is an API",
   "icons":{
-    "x16":"http://www.google.com/images/icons/product/search-16.gif",
-    "x32":"http://www.google.com/images/icons/product/search-32.gif"
+    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
   },
   "protocol":"rest",
   "baseUrl":"https://example.appspot.com/_ah/api/root/v1/",


### PR DESCRIPTION
* include required query parameters in parameterOrder
* updated icon urls
* including API description, title, documentation link, and canonical name
* stringify default values in the discovery doc

Includes two new tests ported from the Java version of the framework.
