### PR TITLE
Begin enveloping protorpc dependencies.

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -20,6 +20,10 @@
 # pylint: disable=wildcard-import
 from __future__ import absolute_import
 
+from protorpc import message_types
+from protorpc import messages
+from protorpc import remote
+
 from .api_config import api, method
 from .api_config import AUTH_LEVEL, EMAIL_SCOPE
 from .api_config import Issuer, LimitDefinition, Namespace

--- a/endpoints/_endpointscfg_impl.py
+++ b/endpoints/_endpointscfg_impl.py
@@ -44,6 +44,20 @@ from __future__ import absolute_import
 import argparse
 import collections
 import contextlib
+import logging
+import os
+import re
+import sys
+import urllib
+import urllib2
+
+import yaml
+from google.appengine.ext import testbed
+
+from . import api_config
+from . import openapi_generator
+from . import remote
+
 # Conditional import, pylint: disable=g-import-not-at-top
 try:
   import json
@@ -51,18 +65,7 @@ except ImportError:
   # If we can't find json packaged with Python import simplejson, which is
   # packaged with the SDK.
   import simplejson as json
-import logging
-import os
-import re
-import sys
-import urllib
-import urllib2
-from . import api_config
-from protorpc import remote
-from . import openapi_generator
-import yaml
 
-from google.appengine.ext import testbed
 
 DISCOVERY_DOC_BASE = ('https://webapis-discovery.appspot.com/_ah/api/'
                       'discovery/v1/apis/generate/')

--- a/endpoints/api_config.py
+++ b/endpoints/api_config.py
@@ -39,25 +39,22 @@ import json
 import logging
 import re
 
-from . import api_exceptions
-from . import message_parser
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-from protorpc import util
+from google.appengine.api import app_identity
 
 import attr
 import semver
+from protorpc import util
 
+from . import api_exceptions
+from . import constants
+from . import message_parser
+from . import message_types
+from . import messages
+from . import remote
 from . import resource_container
+from . import types as endpoints_types
 from . import users_id_token
 from . import util as endpoints_util
-from . import types as endpoints_types
-from . import constants
-
-from google.appengine.api import app_identity
-
 
 _logger = logging.getLogger(__name__)
 package = 'google.appengine.endpoints'

--- a/endpoints/api_exceptions.py
+++ b/endpoints/api_exceptions.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 import httplib
 
-from protorpc import remote
+from . import remote
 
 
 class ServiceException(remote.ApplicationError):

--- a/endpoints/apiserving.py
+++ b/endpoints/apiserving.py
@@ -66,22 +66,20 @@ import json
 import logging
 import os
 
+from google.appengine.api import app_identity
+
+from endpoints_management.control import client as control_client
+from endpoints_management.control import wsgi as control_wsgi
+from protorpc.wsgi import service as wsgi_service
+
 from . import api_config
 from . import api_exceptions
 from . import endpoints_dispatcher
+from . import message_types
+from . import messages
 from . import protojson
-
-from google.appengine.api import app_identity
-from endpoints_management.control import client as control_client
-from endpoints_management.control import wsgi as control_wsgi
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-from protorpc.wsgi import service as wsgi_service
-
+from . import remote
 from . import util
-
 
 _logger = logging.getLogger(__name__)
 package = 'google.appengine.endpoints'

--- a/endpoints/directory_list_generator.py
+++ b/endpoints/directory_list_generator.py
@@ -23,6 +23,7 @@ import urlparse
 
 from . import util
 
+
 class DirectoryListGenerator(object):
   """Generates a discovery directory list from a ProtoRPC service.
 

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -23,12 +23,11 @@ import re
 
 from . import api_exceptions
 from . import message_parser
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+from . import message_types
+from . import messages
+from . import remote
 from . import resource_container
 from . import util
-
 
 _logger = logging.getLogger(__name__)
 _PATH_VARIABLE_PATTERN = r'{([a-zA-Z_][a-zA-Z_.\d]*)}'

--- a/endpoints/endpoints_dispatcher.py
+++ b/endpoints/endpoints_dispatcher.py
@@ -32,6 +32,7 @@ import logging
 import re
 import urlparse
 import wsgiref
+
 import pkg_resources
 
 from . import api_config_manager
@@ -41,7 +42,6 @@ from . import discovery_service
 from . import errors
 from . import parameter_converter
 from . import util
-
 
 _logger = logging.getLogger(__name__)
 

--- a/endpoints/endpointscfg.py
+++ b/endpoints/endpointscfg.py
@@ -23,9 +23,9 @@ information about this script's capabilities.
 """
 
 import sys
+
 import _endpointscfg_setup  # pylint: disable=unused-import
 from endpoints._endpointscfg_impl import main
-
 
 if __name__ == '__main__':
   main(sys.argv)

--- a/endpoints/errors.py
+++ b/endpoints/errors.py
@@ -22,7 +22,6 @@ import logging
 
 from . import generated_error_info
 
-
 __all__ = ['BackendError',
            'BasicTypeParameterError',
            'EnumRejectionError',

--- a/endpoints/generated_error_info.py
+++ b/endpoints/generated_error_info.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 
 import collections
 
-
 _ErrorInfo = collections.namedtuple(
     '_ErrorInfo', ['http_status', 'rpc_status', 'reason', 'domain'])
 

--- a/endpoints/message_parser.py
+++ b/endpoints/message_parser.py
@@ -23,9 +23,8 @@ from __future__ import absolute_import
 
 import re
 
-from protorpc import message_types
-from protorpc import messages
-
+from . import message_types
+from . import messages
 
 __all__ = ['MessageTypeToJsonSchema']
 

--- a/endpoints/openapi_generator.py
+++ b/endpoints/openapi_generator.py
@@ -15,19 +15,18 @@
 """A library for converting service configs to OpenAPI (Swagger) specs."""
 from __future__ import absolute_import
 
+import hashlib
 import json
 import logging
 import re
-import hashlib
 
 from . import api_exceptions
 from . import message_parser
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+from . import message_types
+from . import messages
+from . import remote
 from . import resource_container
 from . import util
-
 
 _logger = logging.getLogger(__name__)
 

--- a/endpoints/parameter_converter.py
+++ b/endpoints/parameter_converter.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import
 
 from . import errors
 
-
 __all__ = ['transform_parameter_value']
 
 

--- a/endpoints/protojson.py
+++ b/endpoints/protojson.py
@@ -17,8 +17,9 @@ from __future__ import absolute_import
 
 import base64
 
-from protorpc import messages
 from protorpc import protojson
+
+from . import messages
 
 # pylint: disable=g-bad-name
 

--- a/endpoints/resource_container.py
+++ b/endpoints/resource_container.py
@@ -15,8 +15,8 @@
 """Module for a class that contains a request body resource and parameters."""
 from __future__ import absolute_import
 
-from protorpc import message_types
-from protorpc import messages
+from . import message_types
+from . import messages
 
 
 class ResourceContainer(object):

--- a/endpoints/test/api_config_manager_test.py
+++ b/endpoints/test/api_config_manager_test.py
@@ -17,7 +17,7 @@
 import re
 import unittest
 
-import endpoints.api_config_manager as api_config_manager
+from endpoints import api_config_manager
 
 
 class ApiConfigManagerTest(unittest.TestCase):

--- a/endpoints/test/api_config_test.py
+++ b/endpoints/test/api_config_test.py
@@ -18,19 +18,17 @@ import itertools
 import json
 import unittest
 
-import endpoints.api_config as api_config
-from endpoints.api_config import ApiConfigGenerator
-from endpoints.api_config import AUTH_LEVEL
-from endpoints.constants import API_EXPLORER_CLIENT_ID
-import endpoints.api_exceptions as api_exceptions
 import mock
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
-import endpoints.resource_container as resource_container
-
 import test_util
+from endpoints import api_config
+from endpoints import api_exceptions
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+from endpoints import resource_container
+from endpoints.api_config import AUTH_LEVEL
+from endpoints.api_config import ApiConfigGenerator
+from endpoints.constants import API_EXPLORER_CLIENT_ID
 
 package = 'api_config_test'
 _DESCRIPTOR_PATH_PREFIX = ''

--- a/endpoints/test/apiserving_test.py
+++ b/endpoints/test/apiserving_test.py
@@ -28,21 +28,15 @@ import unittest
 import urllib2
 
 import mock
-
-import endpoints.api_config as api_config
-import endpoints.api_exceptions as api_exceptions
-import endpoints.apiserving as apiserving
-from protorpc import message_types
-from protorpc import messages
-from protorpc import protojson
-from protorpc import registry
-from protorpc import remote
-from protorpc import transport
-
-import endpoints.resource_container as resource_container
 import test_util
-
 import webtest
+from endpoints import api_config
+from endpoints import api_exceptions
+from endpoints import apiserving
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+from endpoints import resource_container
 
 package = 'endpoints.test'
 

--- a/endpoints/test/conftest.py
+++ b/endpoints/test/conftest.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch
 import os
+
 import pytest
+from mock import patch
 
 # The environment settings in this section were extracted from the
 # google.appengine.ext.testbed library, as extracted from version

--- a/endpoints/test/directory_list_generator_test.py
+++ b/endpoints/test/directory_list_generator_test.py
@@ -18,18 +18,14 @@ import json
 import os
 import unittest
 
-import endpoints.api_config as api_config
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
-import endpoints.api_request as api_request
-import endpoints.apiserving as apiserving
-import endpoints.directory_list_generator as directory_list_generator
-
 import test_util
-
+from endpoints import api_config
+from endpoints import api_request
+from endpoints import apiserving
+from endpoints import directory_list_generator
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
 
 _GET_REST_API = 'apisdev.getRest'
 _GET_RPC_API = 'apisdev.getRpc'

--- a/endpoints/test/discovery_document_test.py
+++ b/endpoints/test/discovery_document_test.py
@@ -16,16 +16,16 @@
 
 import json
 import os.path
-
-import pytest
-import webtest
 import urllib
 
 import endpoints
-import endpoints.discovery_generator as discovery_generator
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+import pytest
+import webtest
+from endpoints import discovery_generator
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+
 
 def make_collection(cls):
     return type(

--- a/endpoints/test/discovery_generator_test.py
+++ b/endpoints/test/discovery_generator_test.py
@@ -18,19 +18,16 @@ import json
 import os
 import unittest
 
-import endpoints.api_config as api_config
-import endpoints.api_exceptions as api_exceptions
-import endpoints.users_id_token as users_id_token
-import endpoints.types as endpoints_types
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
-import endpoints.resource_container as resource_container
-import endpoints.discovery_generator as discovery_generator
 import test_util
-
+from endpoints import api_config
+from endpoints import api_exceptions
+from endpoints import discovery_generator
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+from endpoints import resource_container
+from endpoints import types as endpoints_types
+from endpoints import users_id_token
 
 package = 'DiscoveryGeneratorTest'
 

--- a/endpoints/test/discovery_service_test.py
+++ b/endpoints/test/discovery_service_test.py
@@ -17,17 +17,15 @@
 import os
 import unittest
 
-import endpoints.api_config as api_config
-import endpoints.api_config_manager as api_config_manager
-import endpoints.apiserving as apiserving
-import endpoints.discovery_service as discovery_service
 import test_util
-
 import webtest
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+from endpoints import api_config
+from endpoints import api_config_manager
+from endpoints import apiserving
+from endpoints import discovery_service
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
 
 
 @api_config.api('aservice', 'v3', hostname='aservice.appspot.com',

--- a/endpoints/test/endpoints_dispatcher_test.py
+++ b/endpoints/test/endpoints_dispatcher_test.py
@@ -16,12 +16,11 @@
 
 import unittest
 
-from protorpc import remote
+from endpoints import api_config
+from endpoints import apiserving
+from endpoints import endpoints_dispatcher
+from endpoints import remote
 from webtest import TestApp
-
-import endpoints.api_config as api_config
-import endpoints.apiserving as apiserving
-import endpoints.endpoints_dispatcher as endpoints_dispatcher
 
 
 @api_config.api('aservice', 'v1', hostname='aservice.appspot.com',

--- a/endpoints/test/integration_test.py
+++ b/endpoints/test/integration_test.py
@@ -14,14 +14,14 @@
 
 """Tests against fully-constructed apps"""
 
-import pytest
-import webtest
 import urllib
 
 import endpoints
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+import pytest
+import webtest
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
 
 
 class FileResponse(messages.Message):

--- a/endpoints/test/message_parser_test.py
+++ b/endpoints/test/message_parser_test.py
@@ -18,12 +18,10 @@ import difflib
 import json
 import unittest
 
-import endpoints.message_parser as message_parser
-from protorpc import message_types
-from protorpc import messages
-
 import test_util
-
+from endpoints import message_parser
+from endpoints import message_types
+from endpoints import messages
 
 package = 'TestPackage'
 

--- a/endpoints/test/openapi_generator_test.py
+++ b/endpoints/test/openapi_generator_test.py
@@ -16,19 +16,16 @@
 
 import json
 import unittest
+
 import pytest
-
-import endpoints.api_config as api_config
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
-import endpoints.api_exceptions as api_exceptions
-import endpoints.resource_container as resource_container
-import endpoints.openapi_generator as openapi_generator
 import test_util
-
+from endpoints import api_config
+from endpoints import api_exceptions
+from endpoints import message_types
+from endpoints import messages
+from endpoints import openapi_generator
+from endpoints import remote
+from endpoints import resource_container
 
 package = 'OpenApiGeneratorTest'
 

--- a/endpoints/test/protojson_test.py
+++ b/endpoints/test/protojson_test.py
@@ -17,10 +17,9 @@
 import json
 import unittest
 
-import endpoints.protojson as protojson
-from protorpc import messages
-
 import test_util
+from endpoints import messages
+from endpoints import protojson
 
 
 class MyMessage(messages.Message):

--- a/endpoints/test/resource_container_test.py
+++ b/endpoints/test/resource_container_test.py
@@ -17,15 +17,12 @@
 import json
 import unittest
 
-import endpoints.api_config as api_config
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
-import endpoints.resource_container as resource_container
 import test_util
-
+from endpoints import api_config
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+from endpoints import resource_container
 
 package = 'ResourceContainerTest'
 

--- a/endpoints/test/test_live_auth.py
+++ b/endpoints/test/test_live_auth.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
-import os
-import cStringIO
-import zipfile
-import sys
-import importlib
-import shutil
 import base64
+import cStringIO
+import importlib
+import os
+import shutil
 import subprocess
+import sys
+import tempfile
+import zipfile
+
+import requests  # provided by endpoints-management-python
 
 import pytest
-import requests  # provided by endpoints-management-python
 import yaml
 
 JSON_HEADERS = {'content-type': 'application/json'}

--- a/endpoints/test/test_util.py
+++ b/endpoints/test/test_util.py
@@ -21,6 +21,7 @@ Classes:
 # pylint: disable=g-bad-name
 
 import __future__
+
 import json
 import os
 import StringIO

--- a/endpoints/test/testdata/sample_app/main.py
+++ b/endpoints/test/testdata/sample_app/main.py
@@ -15,15 +15,15 @@
 """This is a sample Hello World API implemented using Google Cloud
 Endpoints."""
 
-# [START imports]
-import endpoints
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
 import copy
 
+# [START imports]
+import endpoints
 from data import AIRPORTS as SOURCE_AIRPORTS
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+
 # [END imports]
 
 AIRPORTS = copy.deepcopy(SOURCE_AIRPORTS)

--- a/endpoints/test/types_test.py
+++ b/endpoints/test/types_test.py
@@ -21,14 +21,12 @@ import string
 import time
 import unittest
 
-import endpoints.api_config as api_config
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
 import test_util
-import endpoints.types as endpoints_types
+from endpoints import api_config
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+from endpoints import types as endpoints_types
 
 
 class ModuleInterfaceTest(test_util.ModuleInterfaceTest,

--- a/endpoints/test/users_id_token_test.py
+++ b/endpoints/test/users_id_token_test.py
@@ -21,24 +21,20 @@ import string
 import time
 import unittest
 
-import mock
-import pytest
-
-import endpoints.api_config as api_config
-
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
-
-import test_util
-import endpoints.users_id_token as users_id_token
-import endpoints.constants as constants
-
 from google.appengine.api import memcache
 from google.appengine.api import oauth
 from google.appengine.api import urlfetch
 from google.appengine.api import users
 
+import mock
+import pytest
+import test_util
+from endpoints import api_config
+from endpoints import constants
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
+from endpoints import users_id_token
 
 # The key response that allows the _SAMPLE_TOKEN to be verified.  This key was
 # retrieved from:

--- a/endpoints/test/util_test.py
+++ b/endpoints/test/util_test.py
@@ -18,11 +18,9 @@ import os
 import sys
 import unittest
 
-import mock
-
 import endpoints._endpointscfg_setup  # pylint: disable=unused-import
-
-import endpoints.util as util
+import mock
+from endpoints import util
 
 MODULES_MODULE = 'google.appengine.api.modules.modules'
 
@@ -72,4 +70,3 @@ class GetProtocolForEnvTest(unittest.TestCase):
 
 if __name__ == '__main__':
   unittest.main()
-

--- a/endpoints/users_id_token.py
+++ b/endpoints/users_id_token.py
@@ -29,15 +29,15 @@ import os
 import re
 import time
 import urllib
-
-from collections import Container as _Container, Iterable as _Iterable
-
-from . import constants
+from collections import Container as _Container
+from collections import Iterable as _Iterable
 
 from google.appengine.api import memcache
 from google.appengine.api import oauth
 from google.appengine.api import urlfetch
 from google.appengine.api import users
+
+from . import constants
 
 try:
   # PyCrypto may not be installed for the import_aeta_test or in dev's

--- a/endpoints/util.py
+++ b/endpoints/util.py
@@ -23,7 +23,6 @@ import os
 import wsgiref.headers
 
 from google.appengine.api import app_identity
-
 from google.appengine.api.modules import modules
 
 


### PR DESCRIPTION
Code can now import `message_types`, `messages`, and `remote` directly from the endpoints library, which gives us flexibility to change things.

Also, all import organization has been standardized using the [isort](https://github.com/timothycrosley/isort) utility for Python.