### PR TITLE
Update local oauth path to use v3 tokeninfo api

### DIFF
--- a/endpoints/test/users_id_token_test.py
+++ b/endpoints/test/users_id_token_test.py
@@ -142,18 +142,19 @@ class UsersIdTokenTestBase(unittest.TestCase):
   _SAMPLE_TIME_NOW = 1360964700
   _SAMPLE_OAUTH_SCOPES = ['https://www.googleapis.com/auth/userinfo.email']
   _SAMPLE_OAUTH_TOKEN_INFO = {
-      'issued_to': ('919214422084-c0jrodnkm7ntttjhhttilqjq5d7l7mu5.apps.'
-                    'googleusercontent.com'),
-      'user_id': '108495933693426793887',
-      'expires_in': 3384,
       'access_type': 'online',
-      'audience': ('919214422084-c0jrodnkm7ntttjhhttilqjq5d7l7mu5.apps.'
+      'aud': ('919214422084-c0jrodnkm7ntttjhhttilqjq5d7l7mu5.apps.'
                    'googleusercontent.com'),
+      'azp': ('919214422084-c0jrodnkm7ntttjhhttilqjq5d7l7mu5.apps.'
+                   'googleusercontent.com'),
+      'email': 'kevind@gmail.com',
+      'email_verified': 'true',
+      'exp': str(_SAMPLE_TIME_NOW + 3384),
+      'expires_in': 3384,
       'scope': (
           'https://www.googleapis.com/auth/userinfo.profile '
           'https://www.googleapis.com/auth/userinfo.email'),
-      'email': 'kevind@gmail.com',
-      'verified_email': True
+      'sub': '108495933693426793887',
   }
 
   def setUp(self):
@@ -431,7 +432,7 @@ class UsersIdTokenTest(UsersIdTokenTestBase):
       status_code = 200
       content = json.dumps(token)
 
-    expected_uri = 'https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=unused_token'
+    expected_uri = 'https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=unused_token'
     with mock.patch.object(urlfetch, 'fetch') as mock_fetch:
       mock_fetch.return_value = DummyResponse()
       users_id_token._set_bearer_user_vars_local(
@@ -454,10 +455,10 @@ class UsersIdTokenTest(UsersIdTokenTestBase):
     self.assertNotIn('ENDPOINTS_AUTH_DOMAIN', os.environ)
 
   def testOauthLocalBadEmail(self):
-    self.assertOauthLocalFailed({'verified_email': False})
+    self.assertOauthLocalFailed({'email_verified': 'false'})
 
   def testOauthLocalBadClientId(self):
-    self.assertOauthLocalFailed({'issued_to': 'abc.appspot.com'})
+    self.assertOauthLocalFailed({'azp': 'abc.appspot.com'})
 
   def testOauthLocalBadScopes(self):
     self.assertOauthLocalFailed({'scope': 'useless_scope and_another'})

--- a/endpoints/users_id_token.py
+++ b/endpoints/users_id_token.py
@@ -73,7 +73,7 @@ _ENV_USE_OAUTH_SCOPE = 'ENDPOINTS_USE_OAUTH_SCOPE'
 _ENV_AUTH_EMAIL = 'ENDPOINTS_AUTH_EMAIL'
 _ENV_AUTH_DOMAIN = 'ENDPOINTS_AUTH_DOMAIN'
 _EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email'
-_TOKENINFO_URL = 'https://www.googleapis.com/oauth2/v1/tokeninfo'
+_TOKENINFO_URL = 'https://www.googleapis.com/oauth2/v3/tokeninfo'
 _MAX_AGE_REGEX = re.compile(r'\s*max-age\s*=\s*(\d+)\s*')
 _CERT_NAMESPACE = '__verify_jwt'
 _ISSUERS = ('accounts.google.com', 'https://accounts.google.com')
@@ -417,12 +417,12 @@ def _set_bearer_user_vars_local(token, allowed_client_ids, scopes):
   if 'email' not in token_info:
     _logger.warning('Oauth token doesn\'t include an email address.')
     return
-  if not token_info.get('verified_email'):
+  if token_info.get('email_verified') != 'true':
     _logger.warning('Oauth token email isn\'t verified.')
     return
 
   # Validate client ID.
-  client_id = token_info.get('issued_to')
+  client_id = token_info.get('azp')
   if (list(allowed_client_ids) != SKIP_CLIENT_ID_CHECK and
       client_id not in allowed_client_ids):
     _logger.warning('Client ID is not allowed: %s', client_id)


### PR DESCRIPTION
When running in the devappserver, we have to verify oauth tokens using Google's tokeninfo api. This brings the codebase up to date with [v3 of the API](https://developers.google.com/identity/protocols/OAuth2UserAgent#validate-access-token).

Fixes #157.