### PR TITLE
Logging overhaul

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -20,6 +20,8 @@
 # pylint: disable=wildcard-import
 from __future__ import absolute_import
 
+import logging
+
 from protorpc import message_types
 from protorpc import messages
 from protorpc import remote
@@ -38,3 +40,6 @@ from .users_id_token import InvalidGetUserCall
 from .users_id_token import SKIP_CLIENT_ID_CHECK
 
 __version__ = '4.5.0'
+
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.INFO)

--- a/endpoints/apiserving.py
+++ b/endpoints/apiserving.py
@@ -564,6 +564,10 @@ def api_server(api_services, **kwargs):
   if 'protocols' in kwargs:
     raise TypeError("__init__() got an unexpected keyword argument 'protocols'")
 
+  from endpoints import _logger as endpoints_logger
+  from endpoints import __version__ as endpoints_version
+  endpoints_logger.info('Initializing Endpoints Framework version %s', endpoints_version)
+
   # Construct the api serving app
   apis_app = _ApiServer(api_services, **kwargs)
   dispatcher = endpoints_dispatcher.EndpointsDispatcherMiddleware(apis_app)
@@ -582,6 +586,10 @@ def api_server(api_services, **kwargs):
   if control_wsgi.running_on_devserver():
     _logger.warn('Running on local devserver, so service control is disabled.')
     return dispatcher
+
+  from endpoints_management import _logger as management_logger
+  from endpoints_management import __version__ as management_version
+  management_logger.info('Initializing Endpoints Management Framework version %s', management_version)
 
   # The DEFAULT 'config' should be tuned so that it's always OK for python
   # App Engine workloads.  The config can be adjusted, but that's probably

--- a/endpoints/endpoints_dispatcher.py
+++ b/endpoints/endpoints_dispatcher.py
@@ -233,7 +233,7 @@ class EndpointsDispatcherMiddleware(object):
                                        'text/html')],
                                      PROXY_HTML, start_response)
     else:
-      _logger.error('Unknown static url requested: %s',
+      _logger.debug('Unknown static url requested: %s',
                     request.relative_url)
       return util.send_wsgi_response('404 Not Found', [('Content-Type',
                                        'text/plain')], 'Not Found',

--- a/endpoints/users_id_token.py
+++ b/endpoints/users_id_token.py
@@ -371,7 +371,7 @@ def _set_bearer_user_vars(allowed_client_ids, scopes):
     _logger.debug('Unable to get authorized scopes.', exc_info=True)
     return
   if not _are_scopes_sufficient(authorized_scopes, sufficient_scopes):
-    _logger.debug('Authorized scopes did not satisfy scope requirements.')
+    _logger.warning('Authorized scopes did not satisfy scope requirements.')
     return
   client_id = oauth.get_client_id(authorized_scopes)
 
@@ -547,7 +547,7 @@ def _get_cached_certs(cert_uri, cache):
   """
   certs = cache.get(cert_uri, namespace=_CERT_NAMESPACE)
   if certs is None:
-    _logger.debug('Cert cache miss')
+    _logger.debug('Cert cache miss for %s', cert_uri)
     try:
       result = urlfetch.fetch(cert_uri)
     except AssertionError:


### PR DESCRIPTION
Package loggers will now have a default logging level of INFO, meaning the DEBUG-level log statements will not be shown.

This is easily overridden in customer code with something like this:
`logging.getLogger('endpoints').setLevel(logging.DEBUG)`

Additionally, some logging levels have been corrected.