### PR TITLE
Bump subminor version (4.6.0 -> 4.6.1)

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -39,7 +39,7 @@ from .users_id_token import get_current_user, get_verified_jwt, convert_jwks_uri
 from .users_id_token import InvalidGetUserCall
 from .users_id_token import SKIP_CLIENT_ID_CHECK
 
-__version__ = '4.6.0'
+__version__ = '4.6.1'
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)

--- a/endpoints/apiserving.py
+++ b/endpoints/apiserving.py
@@ -564,8 +564,8 @@ def api_server(api_services, **kwargs):
   if 'protocols' in kwargs:
     raise TypeError("__init__() got an unexpected keyword argument 'protocols'")
 
-  from endpoints import _logger as endpoints_logger
-  from endpoints import __version__ as endpoints_version
+  from . import _logger as endpoints_logger
+  from . import __version__ as endpoints_version
   endpoints_logger.info('Initializing Endpoints Framework version %s', endpoints_version)
 
   # Construct the api serving app


### PR DESCRIPTION
Rationale: Don't use package name for internal imports