### PR TITLE
Better error when request body found for GET/DELETE method.

### DIFF
--- a/endpoints/openapi_generator.py
+++ b/endpoints/openapi_generator.py
@@ -591,6 +591,11 @@ class OpenApiGenerator(object):
     """
     if isinstance(message_type, resource_container.ResourceContainer):
       base_message_type = message_type.body_message_class()
+      if (request_kind == self.__NO_BODY and
+          base_message_type != message_types.VoidMessage()):
+        msg = ('Method %s specifies a body message in its ResourceContainer, but '
+               'is a HTTP method type that cannot accept a body.') % method_id
+        raise api_exceptions.ApiConfigurationError(msg)
     else:
       base_message_type = message_type
 


### PR DESCRIPTION
If a ResourceContainer has a positional argument, that is treated as a body message. But GET/DELETE requests can't take a request body. This raises an informative error; previously an uninformative KeyError was raised.

Fixes #167.