### PR TITLE
Discovery document / client generation fixes

### DIFF
--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -888,6 +888,13 @@ class DiscoveryGenerator(object):
       descriptor['ownerDomain'] = merged_api_info.namespace.owner_domain
       descriptor['ownerName'] = merged_api_info.namespace.owner_name
       descriptor['packagePath'] = merged_api_info.namespace.package_path or ''
+    else:
+      if merged_api_info.owner_domain is not None:
+        descriptor['ownerDomain'] = merged_api_info.owner_domain
+      if merged_api_info.owner_name is not None:
+        descriptor['ownerName'] = merged_api_info.owner_name
+      if merged_api_info.package_path is not None:
+        descriptor['packagePath'] = merged_api_info.package_path
 
     method_map = {}
     method_collision_tracker = {}

--- a/endpoints/discovery_generator.py
+++ b/endpoints/discovery_generator.py
@@ -322,6 +322,10 @@ class DiscoveryGenerator(object):
     if field.default:
       if isinstance(field, messages.EnumField):
         return field.default.name
+      elif isinstance(field, messages.BooleanField):
+        # The Python standard representation of a boolean value causes problems
+        # when generating client code.
+        return 'true' if field.default else 'false'
       else:
         return str(field.default)
 
@@ -564,7 +568,10 @@ class DiscoveryGenerator(object):
                 [''] * num_enums)
           elif 'default' in prop_value:
             # stringify default values
-            prop_value['default'] = str(prop_value['default'])
+            if prop_value.get('type') == 'boolean':
+              prop_value['default'] = 'true' if prop_value['default'] else 'false'
+            else:
+              prop_value['default'] = str(prop_value['default'])
           key_result['properties'][prop_key].pop('required', None)
 
       for key in ('type', 'id', 'description'):

--- a/test/discovery_document_test.py
+++ b/test/discovery_document_test.py
@@ -139,6 +139,7 @@ class MultipleParameterEndpoint(remote.Service):
         child = messages.StringField(3, required=True),
         queryb = messages.StringField(4, required=True),
         querya = messages.StringField(5, required=True),
+        allow = messages.BooleanField(6, default=True),
     ), message_types.VoidMessage, name='param', path='param/{parent}/{child}')
     def param(self, request):
         pass

--- a/test/discovery_generator_test.py
+++ b/test/discovery_generator_test.py
@@ -274,6 +274,36 @@ class DiscoveryGeneratorTest(BaseDiscoveryGeneratorTest):
 
     test_util.AssertDictEqual(expected_discovery, api, self)
 
+  def testNamespaceWithoutNamespace(self):
+    """
+    The owner_domain, owner_name, and package_path can all
+    be specified directly on the api.
+    """
+    @api_config.api(name='root', hostname='example.appspot.com', version='v1',
+                    description='This is an API',
+                    owner_domain='domain', owner_name='name', package_path='path')
+    class MyService(remote.Service):
+      """Describes MyService."""
+
+      @api_config.method(IdField, message_types.VoidMessage, path='entries',
+                         http_method='GET', name='get_entry')
+      def entries_get(self, unused_request):
+        """Id (integer) field type in the query parameters."""
+        return message_types.VoidMessage()
+
+    api = json.loads(self.generator.pretty_print_config_to_json(MyService))
+
+    try:
+      pwd = os.path.dirname(os.path.realpath(__file__))
+      test_file = os.path.join(pwd, 'testdata', 'discovery', 'namespace.json')
+      with open(test_file) as f:
+        expected_discovery = json.loads(f.read())
+    except IOError as e:
+      print 'Could not find expected output file ' + test_file
+      raise e
+
+    test_util.AssertDictEqual(expected_discovery, api, self)
+
 class DiscoveryMultiClassGeneratorTest(BaseDiscoveryGeneratorTest):
 
   def testMultipleClassService(self):

--- a/test/testdata/discovery/bar_endpoint.json
+++ b/test/testdata/discovery/bar_endpoint.json
@@ -217,7 +217,7 @@
         },
 	"active": {
 	  "type": "boolean",
-	  "default": "True"
+	  "default": "true"
 	}
       },
       "type": "object"

--- a/test/testdata/discovery/multiple_parameter_endpoint.json
+++ b/test/testdata/discovery/multiple_parameter_endpoint.json
@@ -53,7 +53,12 @@
           "location": "query",
           "required": true,
           "type": "string"
-        }
+        },
+	"allow": {
+	  "default": "true",
+	  "location": "query",
+	  "type": "boolean"
+	}
       },
       "path": "param/{parent}/{child}",
       "scopes": [


### PR DESCRIPTION
Discovery docs will now send boolean default values such that they will be correctly written into Java clients. Additionally, the namespace attributes such as `owner_domain` will be respected when set on the API instead of inside a namespace object.